### PR TITLE
PolarMACE: route MM->QM fields via source-target and return ML-MM electrostatic energy

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -179,6 +179,8 @@ class MACECalculator(Calculator):
                     "stress",
                 ]
             )
+            if model_type == "PolarMACE":
+                self.implemented_properties.append("ml_mm_electrostatic_energy")
             if kwargs.get("compute_atomic_stresses", False):
                 self.implemented_properties.extend(["stresses", "virials"])
                 self.compute_atomic_stresses = True
@@ -397,6 +399,7 @@ class MACECalculator(Calculator):
                 {
                     "interaction_energy": [],
                     "electrostatic_energy": [],
+                    "ml_mm_electrostatic_energy": [],
                     "electron_energy": [],
                     "spins": [num_atoms],
                     "density_coefficients": [num_atoms, self.density_dim],
@@ -537,6 +540,11 @@ class MACECalculator(Calculator):
                     (
                         "electrostatic_energy",
                         "electrostatic_energy",
+                        self.energy_units_to_eV,
+                    ),
+                    (
+                        "ml_mm_electrostatic_energy",
+                        "ml_mm_electrostatic_energy",
                         self.energy_units_to_eV,
                     ),
                     ("electron_energy", "electron_energy", self.energy_units_to_eV),

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -795,6 +795,7 @@ class PolarMACE(ScaleShiftMACE):
         Verified bit-equivalent on the QM rows in
         `graph_electrostatics/tests/test_features_source_target.py`.
         """
+
         mm_positions = _get_optional_data_tensor(data, "mm_positions")
         mm_charges = _get_optional_data_tensor(data, "mm_charges")
         mm_multipoles = _get_optional_data_tensor(data, "mm_multipoles")
@@ -909,6 +910,56 @@ class PolarMACE(ScaleShiftMACE):
         if field_from_mul_ir is not None:
             mm_field_feats = field_from_mul_ir(mm_field_feats)
         return mm_field_feats, mm_positions
+
+    def _ml_mm_coulomb(
+        self,
+        ml_charges: torch.Tensor,
+        ml_positions: torch.Tensor,
+        ml_batch: torch.Tensor,
+        mm_charges: Optional[torch.Tensor],
+        mm_positions: Optional[torch.Tensor],
+        mm_batch: Optional[torch.Tensor],
+        num_graphs: int,
+    ):
+        if mm_positions is None or mm_charges is None:
+            return torch.zeros(
+                num_graphs,
+                device=ml_positions.device,
+                dtype=ml_positions.dtype,
+            )
+
+        mm_positions = mm_positions.to(device=ml_positions.device, dtype=ml_positions.dtype)
+        mm_charges = mm_charges.to(device=ml_positions.device, dtype=ml_positions.dtype).reshape(-1)
+        if mm_positions.numel() == 0 or mm_charges.numel() == 0:
+            return torch.zeros(num_graphs, device=ml_positions.device, dtype=ml_positions.dtype)
+        if mm_batch is None:
+            mm_batch = torch.zeros(
+                mm_positions.shape[0], dtype=torch.long, device=ml_positions.device
+            )
+        else:
+            mm_batch = mm_batch.to(device=ml_positions.device, dtype=torch.long).reshape(-1)
+
+        # Coulomb prefactor (eV·Å)
+        k_e = 14.3996454784255
+
+        # pairwise distances
+        rij = ml_positions[:, None, :] - mm_positions[None, :, :]
+        r = torch.linalg.norm(rij, dim=-1).clamp_min(1e-6)
+
+        qi = ml_charges[:, None]
+        qj = mm_charges[None, :]
+
+        # same graph mask
+        same = ml_batch[:, None] == mm_batch[None, :]
+
+        e_pair = k_e * qi * qj / r
+        e_pair = torch.where(same, e_pair, 0.0)
+
+        # sum per graph
+        e_ml = e_pair.sum(dim=1)
+        e_graph = scatter_sum(e_ml, ml_batch, dim=0, dim_size=num_graphs)
+
+        return e_graph
 
     def forward(
         self,
@@ -1267,9 +1318,27 @@ class PolarMACE(ScaleShiftMACE):
             pbc=data["pbc"].view(-1, 3),
             force_pbc_evaluator=use_pbc_evaluator,
         )
+
+        mm_positions = _get_optional_data_tensor(data, "mm_positions")
+        mm_charges = _get_optional_data_tensor(data, "mm_charges")
+        mm_source_batch = _get_optional_data_tensor(data, "mm_source_batch")
+        if not (mm_positions is None or mm_charges is None):
+            ml_charges = charge_density_mul_ir[:, 0]
+            ml_mm_electrostatic_energy = self._ml_mm_coulomb(
+                ml_charges,
+                positions,
+                data["batch"],
+                mm_charges,
+                mm_positions_for_grad,
+                mm_source_batch,
+                num_graphs,
+            )
+        else:
+            ml_mm_electrostatic_energy = torch.zeros_like(electro_energy)
         total_energy = (
             total_energy
             + electro_energy
+            + ml_mm_electrostatic_energy
             + torch.sum(external_potential[:, 1:] * total_dipole, dim=-1)
         )
 
@@ -1334,6 +1403,7 @@ class PolarMACE(ScaleShiftMACE):
             "dipole": total_dipole,
             "total_charge": total_charge,
             "electrostatic_energy": electro_energy,
+            "ml_mm_electrostatic_energy": ml_mm_electrostatic_energy,
             "electron_energy": le_total,
             "electrostatic_potentials": esps,
             "spin_charge_density": spin_charge_density_mul_ir,

--- a/tests/test_mm_field_routes.py
+++ b/tests/test_mm_field_routes.py
@@ -153,10 +153,36 @@ def _run_route(model, data, route: str) -> dict:
     out = model(data, training=False, compute_force=True)
     energy = out["energy"].detach().clone()
     forces = out["forces"].detach().clone()
+    ml_mm_electrostatic_energy = out["ml_mm_electrostatic_energy"].detach().clone()
     mm_forces = out["mm_forces"]
     assert mm_forces is not None, "expected mm_forces in output when MM input present"
     mm_forces = mm_forces.detach().clone()
-    return {"energy": energy, "forces": forces, "mm_forces": mm_forces}
+    charges = out["charges"].detach().clone()
+    return {
+        "energy": energy,
+        "forces": forces,
+        "mm_forces": mm_forces,
+        "ml_mm_electrostatic_energy": ml_mm_electrostatic_energy,
+        "charges": charges,
+    }
+
+
+def _direct_ml_mm_coulomb(charges, data) -> torch.Tensor:
+    k_e = 14.3996454784255
+    positions = data["positions"]
+    mm_positions = data["mm_positions"]
+    mm_charges = data["mm_charges"]
+    batch = data["batch"]
+    mm_batch = data["mm_source_batch"]
+
+    rij = positions[:, None, :] - mm_positions[None, :, :]
+    r = torch.linalg.norm(rij, dim=-1).clamp_min(1e-6)
+    e_pair = k_e * charges[:, None] * mm_charges[None, :] / r
+    e_pair = torch.where(batch[:, None] == mm_batch[None, :], e_pair, 0.0)
+    e_atom = e_pair.sum(dim=1)
+    return torch.zeros(
+        int(batch.max().item()) + 1, dtype=positions.dtype, device=positions.device
+    ).scatter_add_(0, batch, e_atom)
 
 
 def test_default_route_is_source_target():
@@ -197,6 +223,12 @@ def test_mm_field_routes_energy_force_equivalence(dtype, atol):
     torch.testing.assert_close(
         out_st["mm_forces"], out_lg["mm_forces"], atol=atol, rtol=atol
     )
+    torch.testing.assert_close(
+        out_st["ml_mm_electrostatic_energy"],
+        out_lg["ml_mm_electrostatic_energy"],
+        atol=atol,
+        rtol=atol,
+    )
 
 
 def test_mm_forces_nontrivial_so_test_is_meaningful():
@@ -208,3 +240,14 @@ def test_mm_forces_nontrivial_so_test_is_meaningful():
     data = _build_mm_batch(device, torch.float64)
     out = _run_route(model, data, "source_target")
     assert out["mm_forces"].abs().max().item() > 1e-12
+
+
+def test_ml_mm_electrostatic_energy_matches_direct_pair_sum():
+    device = torch.device("cpu")
+    model = _build_minimal_model(device, torch.float64)
+    data = _build_mm_batch(device, torch.float64)
+    out = _run_route(model, data, "source_target")
+    expected = _direct_ml_mm_coulomb(out["charges"], data)
+    torch.testing.assert_close(
+        out["ml_mm_electrostatic_energy"], expected, atol=1e-9, rtol=1e-9
+    )


### PR DESCRIPTION
## Summary
- route PolarMACE MM->QM field features through the source-target descriptor path and keep the legacy path toggle for equivalence checks
- add the explicit ML-MM Coulomb contribution into `total_energy` and return it separately as `ml_mm_electrostatic_energy`
- expose the new energy component through `MACECalculator` and extend the MM-field route tests with route-equivalence and direct pair-sum validation

## Testing
- `python -m pytest -q /home/jerry528/MLMM/mace/tests/test_mm_field_routes.py`
- `python -m pytest -q /home/jerry528/MLMM/mace/tests/test_polar_models.py -k energy_components`

## Notes
- `electrostatic_energy` remains the existing model electrostatic term; the new `ml_mm_electrostatic_energy` is returned separately so the ML-MM contribution can be inspected directly.
- local untracked files `.codex` and `mace/modules/extensions_BAK.py` were intentionally left out of the PR.