### PR TITLE
Optimize non-SOC contractions and add benchmarks

### DIFF
--- a/benchmarks/benchmark_mace.py
+++ b/benchmarks/benchmark_mace.py
@@ -1,0 +1,145 @@
+import torch
+import numpy as np
+from tqdm import tqdm
+import ase.io
+from e3nn import o3
+
+from mace import modules, tools, data
+from mace.data import config_from_atoms, AtomicData
+from mace.tools import torch_geometric
+from mace.modules.utils import get_edge_vectors_and_lengths
+from mace.cli.convert_e3nn_cueq import run as convert_e3nn_cueq
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+torch.set_default_dtype(torch.float64)
+
+# === Load structure and prepare batch ===
+table = tools.AtomicNumberTable([26])
+atomic_energies = np.array([0.0], dtype=float)
+
+at = ase.io.read("/home/coder/project/magnetic-mace/data/ace_ralf_data_Fe/exp_usual_mace/defects_ats.xyz", "-1")
+configs = [config_from_atoms(at)]
+magmoms = torch.tensor(at.arrays["dft_magmom"], dtype=torch.float64, requires_grad=True)
+configs[0].magmom = magmoms
+
+atomic_data_list = [AtomicData.from_config(cfg, z_table=table, cutoff=5.0) for cfg in configs]
+batch = next(iter(torch_geometric.dataloader.DataLoader(atomic_data_list, batch_size=1)))
+batch = batch.to(device)
+
+# === Result container ===
+results = []
+
+def benchmark_mace_interaction_product(model, batch, iterations=20):
+    interaction_times = [[], []]
+    product_times = [[], []]
+
+    positions = batch["positions"]
+    node_attrs = batch["node_attrs"]
+    magmom = batch["magmom"]
+    edge_index = batch["edge_index"]
+    shifts = batch["shifts"]
+    sender, receiver = edge_index
+
+    node_feats = model.node_embedding(node_attrs)
+    vectors, lengths = get_edge_vectors_and_lengths(positions, edge_index, shifts)
+    edge_attrs = model.spherical_harmonics(vectors)
+    edge_feats = model.radial_embedding(lengths, node_attrs, edge_index, model.atomic_numbers)
+
+    for _ in range(iterations):
+        nf = node_feats.clone()
+        for layer_idx in range(2):
+            interaction = model.interactions[layer_idx]
+            product = model.products[layer_idx]
+
+            torch.cuda.synchronize()
+            t0 = torch.cuda.Event(enable_timing=True)
+            t1 = torch.cuda.Event(enable_timing=True)
+            t0.record()
+
+            nf, sc = interaction(
+                node_attrs=node_attrs,
+                node_feats=nf,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=edge_index,
+            )
+
+            t1.record()
+            torch.cuda.synchronize()
+            interaction_times[layer_idx].append(t0.elapsed_time(t1))  # ms
+
+            t0.record()
+            nf = product(
+                node_feats=nf,
+                sc=sc,
+                node_attrs=node_attrs,
+            )
+            t1.record()
+            torch.cuda.synchronize()
+            product_times[layer_idx].append(t0.elapsed_time(t1))  # ms
+
+    return {
+        "interaction_avg": [np.mean(t) for t in interaction_times],
+        "interaction_std": [np.std(t) for t in interaction_times],
+        "product_avg": [np.mean(t) for t in product_times],
+        "product_std": [np.std(t) for t in product_times],
+    }
+
+# === Loop over different hidden_irreps ===
+irreps_list = ["128x0e", "128x0e+128x1o", "128x0e+128x1o+128x2e"]
+
+for HI in irreps_list:
+    print(f"\n--- Benchmarking for hidden_irreps = {HI} ---")
+
+    model_config = dict(
+        r_max=5,
+        num_bessel=8,
+        num_polynomial_cutoff=5,
+        max_ell=3,
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticDensityInteractionBlock"
+        ],
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticDensityResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=1,
+        hidden_irreps=o3.Irreps(HI),
+        MLP_irreps=o3.Irreps("16x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=atomic_energies,
+        avg_num_neighbors=8,
+        atomic_numbers=table.zs,
+        correlation=3,
+        radial_type="bessel",
+        contraction_cls_first="SymmetricContraction",
+        contraction_cls="SymmetricContraction",
+        atomic_inter_scale=[1.0],
+        atomic_inter_shift=[0.0, 0.1],
+    )
+
+    model = modules.ScaleShiftMACE(**model_config)
+    model = convert_e3nn_cueq(model).to(device)
+
+    # Warm-up
+    for _ in tqdm(range(10), desc="Warming up"):
+        model(batch)
+
+    # Benchmark
+    timing = benchmark_mace_interaction_product(model, batch, iterations=20)
+    results.append((HI, timing))
+
+# === Final Summary Table ===
+print("\n=== Summary Table ===")
+print("{:<35} {:>15} {:>15} {:>15} {:>15}".format(
+    "Hidden Irreps", "Inter1 (ms)", "Prod1 (ms)", "Inter2 (ms)", "Prod2 (ms)"
+))
+
+for HI, timing in results:
+    print("{:<35} {:>6.2f} ± {:<5.2f} {:>6.2f} ± {:<5.2f} {:>6.2f} ± {:<5.2f} {:>6.2f} ± {:<5.2f}".format(
+        HI,
+        timing["interaction_avg"][0], timing["interaction_std"][0],
+        timing["product_avg"][0],     timing["product_std"][0],
+        timing["interaction_avg"][1], timing["interaction_std"][1],
+        timing["product_avg"][1],     timing["product_std"][1],
+    ))

--- a/benchmarks/benchmark_magmace.py
+++ b/benchmarks/benchmark_magmace.py
@@ -1,0 +1,158 @@
+import torch
+import numpy as np
+from tqdm import tqdm
+import ase.io
+from e3nn import o3
+
+from mace import modules, tools, data
+from mace.data import config_from_atoms, AtomicData
+from mace.tools import torch_geometric
+from mace.modules.utils import get_edge_vectors_and_lengths
+from mace.cli.convert_e3nn_cueq import run as convert_e3nn_cueq
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+torch.set_default_dtype(torch.float64)
+
+# === Load structure and prepare batch ===
+table = tools.AtomicNumberTable([26])
+atomic_energies = np.array([0.0], dtype=float)
+
+at = ase.io.read("/home/coder/project/magnetic-mace/data/ace_ralf_data_Fe/exp_usual_mace/defects_ats.xyz", "-1")
+configs = [config_from_atoms(at)]
+magmoms = torch.tensor(at.arrays["dft_magmom"], dtype=torch.float64, requires_grad=True)
+configs[0].magmom = magmoms
+
+atomic_data_list = [AtomicData.from_config(cfg, z_table=table, cutoff=5.0) for cfg in configs]
+batch = next(iter(torch_geometric.dataloader.DataLoader(atomic_data_list, batch_size=1)))
+batch = batch.to(device)
+
+# === Result container ===
+results = []
+
+def benchmark_mace_interaction_product(model, batch, iterations=20):
+    interaction_times = [[], []]
+    product_times = [[], []]
+
+    positions = batch["positions"]
+    node_attrs = batch["node_attrs"]
+    magmom = batch["magmom"]
+    edge_index = batch["edge_index"]
+    shifts = batch["shifts"]
+    sender, receiver = edge_index
+
+    node_feats = model.node_embedding(node_attrs)
+    vectors, lengths = get_edge_vectors_and_lengths(positions, edge_index, shifts)
+    edge_attrs = model.spherical_harmonics(vectors)
+    edge_feats = model.radial_embedding(lengths, node_attrs, edge_index, model.atomic_numbers)
+
+    magmom_lengths = torch.norm(magmom, dim=-1, keepdim=True)
+    element_scaling = model.m_max[torch.argmax(node_attrs, dim=1)].unsqueeze(-1)
+    magmom_trans = 1 - 2 * (magmom_lengths / element_scaling) ** 2
+    magmom_node_attrs = model.mag_solid_harmoics(magmom)
+    magmom_node_feats = model.mag_radial_embedding(magmom_trans)
+
+    for _ in range(iterations):
+        nf = node_feats.clone()
+        for layer_idx in range(2):
+            interaction = model.interactions[layer_idx]
+            product = model.products[layer_idx]
+
+            torch.cuda.synchronize()
+            t0 = torch.cuda.Event(enable_timing=True)
+            t1 = torch.cuda.Event(enable_timing=True)
+            t0.record()
+
+            nf, sc = interaction(
+                node_attrs=node_attrs,
+                node_feats=nf,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=edge_index,
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs,
+            )
+
+            t1.record()
+            torch.cuda.synchronize()
+            interaction_times[layer_idx].append(t0.elapsed_time(t1))  # ms
+
+            t0.record()
+            nf = product(
+                node_feats=nf,
+                sc=sc,
+                node_attrs=node_attrs,
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs,
+            )
+            t1.record()
+            torch.cuda.synchronize()
+            product_times[layer_idx].append(t0.elapsed_time(t1))  # ms
+
+    return {
+        "interaction_avg": [np.mean(t) for t in interaction_times],
+        "interaction_std": [np.std(t) for t in interaction_times],
+        "product_avg": [np.mean(t) for t in product_times],
+        "product_std": [np.std(t) for t in product_times],
+    }
+
+# === Loop over different hidden_irreps ===
+irreps_list = ["128x0e", "128x0e+128x1o", "128x0e+128x1o+128x2e"]
+
+for HI in irreps_list:
+    print(f"\n--- Benchmarking for hidden_irreps = {HI} ---")
+
+    model_config = dict(
+        r_max=5,
+        num_bessel=8,
+        num_polynomial_cutoff=5,
+        max_ell=3,
+        interaction_cls_first=modules.interaction_classes[
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock"
+        ],
+        interaction_cls=modules.interaction_classes[
+            "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=1,
+        hidden_irreps=o3.Irreps(HI),
+        MLP_irreps=o3.Irreps("16x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=atomic_energies,
+        avg_num_neighbors=8,
+        atomic_numbers=table.zs,
+        correlation=3,
+        radial_type="bessel",
+        contraction_cls_first="SymmetricContraction",
+        contraction_cls="SymmetricContraction",
+        atomic_inter_scale=[1.0],
+        atomic_inter_shift=[0.0, 0.1],
+        m_max=[4.0],
+        num_mag_radial_basis=8,
+        max_m_ell=1,
+    )
+
+    model = modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE(**model_config)
+    model = convert_e3nn_cueq(model).to(device)
+
+    # Warm-up
+    for _ in tqdm(range(10), desc="Warming up"):
+        model(batch, compute_magforces=False)
+
+    # Benchmark
+    timing = benchmark_mace_interaction_product(model, batch, iterations=20)
+    results.append((HI, timing))
+
+# === Final Summary Table ===
+print("\n=== Summary Table ===")
+print("{:<35} {:>15} {:>15} {:>15} {:>15}".format(
+    "Hidden Irreps", "Inter1 (ms)", "Prod1 (ms)", "Inter2 (ms)", "Prod2 (ms)"
+))
+
+for HI, timing in results:
+    print("{:<35} {:>6.2f} ± {:<5.2f} {:>6.2f} ± {:<5.2f} {:>6.2f} ± {:<5.2f} {:>6.2f} ± {:<5.2f}".format(
+        HI,
+        timing["interaction_avg"][0], timing["interaction_std"][0],
+        timing["product_avg"][0],     timing["product_std"][0],
+        timing["interaction_avg"][1], timing["interaction_std"][1],
+        timing["product_avg"][1],     timing["product_std"][1],
+    ))

--- a/benchmarks/nonSOC/benchmark_nonsoc_hidden_irreps.py
+++ b/benchmarks/nonSOC/benchmark_nonsoc_hidden_irreps.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Benchmark non-SOC MACE model forward time for L=0 and L=1 across k values."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+import warnings
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import numpy as np
+import torch
+from e3nn import o3
+
+from mace import data, modules, tools
+from mace.tools import torch_geometric
+
+
+DEFAULT_MODEL = "MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE"
+DEFAULT_INTERACTION_FIRST = "RealAgnosticDensityInteractionBlock"
+DEFAULT_INTERACTION = "MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--interaction_first",
+        "--interaction-cls-first",
+        dest="interaction_first",
+        default=DEFAULT_INTERACTION_FIRST,
+    )
+    parser.add_argument(
+        "--interaction",
+        "--interaction-cls",
+        dest="interaction",
+        default=DEFAULT_INTERACTION,
+    )
+    parser.add_argument(
+        "--contraction_cls_first",
+        "--contraction-cls-first",
+        dest="contraction_cls_first",
+        default="SymmetricContraction",
+    )
+    parser.add_argument(
+        "--contraction_cls",
+        "--contraction-cls",
+        dest="contraction_cls",
+        default="NonSOCSymmetricContraction",
+    )
+    parser.add_argument("--k-values", default="16,32,64,128")
+    parser.add_argument("--l-values", default="0,1")
+    parser.add_argument("--modes", default="reference,optimized,sparse")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repeat", type=int, default=50)
+    parser.add_argument("--num-interactions", type=int, default=2)
+    parser.add_argument("--correlation", type=int, default=3)
+    parser.add_argument("--r-max", type=float, default=4.5)
+    parser.add_argument("--num-bessel", type=int, default=10)
+    parser.add_argument("--num-polynomial-cutoff", type=int, default=5)
+    parser.add_argument("--max-ell", type=int, default=3)
+    parser.add_argument("--avg-num-neighbors", type=float, default=28.243721185921906)
+    parser.add_argument("--num-elements", type=int, default=2)
+    parser.add_argument("--atomic-numbers", default="1,8")
+    parser.add_argument("--atomic-energies", default="0.0,0.0")
+    parser.add_argument("--atomic-inter-scale", default="1.0")
+    parser.add_argument("--atomic-inter-shift", default="0.0")
+    parser.add_argument("--m-max", default="10.0,10.0")
+    parser.add_argument("--num-mag-radial-basis", type=int, default=8)
+    parser.add_argument("--num-mag-radial-basis-one-body", type=int, default=10)
+    parser.add_argument("--max-m-ell", type=int, default=3)
+    parser.add_argument("--distance-transform", default="Agnesi")
+    parser.add_argument("--cutoff", type=float, default=5.0)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def parse_float_list(text: str) -> list[float]:
+    return [float(x.strip()) for x in text.split(",") if x.strip()]
+
+
+def parse_int_list(text: str) -> list[int]:
+    return [int(x.strip()) for x in text.split(",") if x.strip()]
+
+
+def build_batch(cutoff: float):
+    table = tools.AtomicNumberTable([1, 8])
+    config = data.Configuration(
+        atomic_numbers=np.array([8, 1, 1]),
+        positions=np.array(
+            [
+                [0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        ),
+        forces=np.zeros((3, 3), dtype=float),
+        energy=-1.5,
+        charges=np.array([-2.0, 1.0, 1.0]),
+        dipole=np.array([-1.5, 1.5, 2.0]),
+        magmom=np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, -2.0, 0.0],
+                [0.0, 0.0, -3.0],
+            ]
+        ),
+    )
+    atom_data = data.AtomicData.from_config(config, z_table=table, cutoff=cutoff)
+    loader = torch_geometric.dataloader.DataLoader([atom_data], batch_size=1)
+    return table, next(iter(loader))
+
+
+def hidden_irreps_for(k: int, ell_mode: int) -> str:
+    if ell_mode == 0:
+        return f"{k}x0e"
+    if ell_mode == 1:
+        return f"{k}x0e + {k}x1o"
+    raise ValueError(f"Unsupported L value: {ell_mode}")
+
+
+def build_model(args: argparse.Namespace, table: tools.AtomicNumberTable, hidden_irreps: str) -> torch.nn.Module:
+    model_cls = getattr(modules, args.model)
+    interaction_cls_first = modules.interaction_classes[args.interaction_first]
+    interaction_cls = modules.interaction_classes[args.interaction]
+    atomic_numbers = parse_int_list(args.atomic_numbers)
+    atomic_energies = np.array(parse_float_list(args.atomic_energies), dtype=float)
+    atomic_inter_scale = parse_float_list(args.atomic_inter_scale)
+    atomic_inter_shift = parse_float_list(args.atomic_inter_shift)
+    m_max = parse_float_list(args.m_max)
+
+    model_config: dict[str, Any] = dict(
+        r_max=args.r_max,
+        num_bessel=args.num_bessel,
+        num_polynomial_cutoff=args.num_polynomial_cutoff,
+        max_ell=args.max_ell,
+        interaction_cls_first=interaction_cls_first,
+        interaction_cls=interaction_cls,
+        num_interactions=args.num_interactions,
+        num_elements=args.num_elements,
+        hidden_irreps=o3.Irreps(hidden_irreps),
+        MLP_irreps=o3.Irreps("16x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=atomic_energies,
+        avg_num_neighbors=args.avg_num_neighbors,
+        atomic_numbers=atomic_numbers if atomic_numbers else table.zs,
+        correlation=args.correlation,
+        radial_type="bessel",
+        contraction_cls_first=args.contraction_cls_first,
+        contraction_cls=args.contraction_cls,
+        atomic_inter_scale=atomic_inter_scale,
+        atomic_inter_shift=atomic_inter_shift,
+        m_max=m_max,
+        num_mag_radial_basis=args.num_mag_radial_basis,
+        max_m_ell=args.max_m_ell,
+        num_mag_radial_basis_one_body=args.num_mag_radial_basis_one_body,
+        heads=["default"],
+        distance_transform=args.distance_transform,
+    )
+    return model_cls(**model_config)
+
+
+@contextmanager
+def contraction_mode(model: torch.nn.Module, mode: str) -> Iterator[None]:
+    touched = []
+    for _, mod in model.named_modules():
+        if mod.__class__.__name__ != "NonSOCContraction":
+            continue
+        if not hasattr(mod, "forward_reference"):
+            continue
+        touched.append((mod, mod.forward))
+        if mode == "reference":
+            mod.forward = mod.forward_reference
+        elif mode == "optimized":
+            mod.forward = mod.forward_optimized
+        elif mode == "sparse":
+            mod.forward = mod.forward_sparse
+        else:
+            raise ValueError(f"Unknown mode: {mode}")
+    try:
+        yield
+    finally:
+        for mod, old_forward in touched:
+            mod.forward = old_forward
+
+
+def synchronize_if_needed(device: str) -> None:
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+
+
+def benchmark(fn, warmup: int, repeat: int, device: str) -> tuple[float, float]:
+    for _ in range(warmup):
+        fn()
+    synchronize_if_needed(device)
+
+    if device.startswith("cuda"):
+        timings_ms = []
+        for _ in range(repeat):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            fn()
+            end.record()
+            torch.cuda.synchronize()
+            timings_ms.append(start.elapsed_time(end))
+        return statistics.mean(timings_ms) / 1e3, statistics.pstdev(timings_ms) / 1e3
+
+    timings_s = []
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        fn()
+        timings_s.append(time.perf_counter() - t0)
+    return statistics.mean(timings_s), statistics.pstdev(timings_s)
+
+
+def main() -> None:
+    args = parse_args()
+
+    warnings.filterwarnings(
+        "ignore",
+        message="The TorchScript type system doesn't support instance-level annotations",
+        category=UserWarning,
+    )
+    torch.set_default_dtype(torch.float64)
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    k_values = parse_int_list(args.k_values)
+    l_values = parse_int_list(args.l_values)
+    modes = [item.strip() for item in args.modes.split(",") if item.strip()]
+
+    table, batch = build_batch(args.cutoff)
+    batch_dict = {
+        key: value.to(args.device) if hasattr(value, "to") else value
+        for key, value in batch.to_dict().items()
+    }
+
+    print(f"model={args.model}")
+    print(f"interaction_first={args.interaction_first}")
+    print(f"interaction={args.interaction}")
+    print(f"contraction_cls_first={args.contraction_cls_first}")
+    print(f"contraction_cls={args.contraction_cls}")
+    print(f"device={args.device}")
+    print("L k mode init_ok forward_ok mean_ms std_ms energy0 n_nonsoc")
+
+    for ell_mode in l_values:
+        for k in k_values:
+            hidden_irreps = hidden_irreps_for(k, ell_mode)
+            try:
+                torch.manual_seed(args.seed)
+                np.random.seed(args.seed)
+                model = build_model(args, table, hidden_irreps).to(args.device)
+                model.eval()
+                init_ok = True
+                n_nonsoc = sum(
+                    1 for _, mod in model.named_modules() if mod.__class__.__name__ == "NonSOCContraction"
+                )
+            except Exception as exc:  # noqa: BLE001
+                for mode in modes:
+                    print(f"{ell_mode} {k} {mode} False False nan nan init_error:{exc!s} 0")
+                continue
+
+            for mode in modes:
+                def run():
+                    with contraction_mode(model, mode):
+                        return model(
+                            batch_dict,
+                            training=False,
+                            compute_force=False,
+                            compute_stress=False,
+                            compute_virials=False,
+                            compute_hessian=False,
+                            compute_magforces=False,
+                        )
+
+                try:
+                    out = run()
+                    energy0 = float(out["energy"][0]) if "energy" in out else float("nan")
+                    mean_s, std_s = benchmark(run, args.warmup, args.repeat, args.device)
+                    print(
+                        f"{ell_mode} {k} {mode} {init_ok} True "
+                        f"{mean_s*1e3:.3f} {std_s*1e3:.3f} {energy0:.12f} {n_nonsoc}"
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    print(
+                        f"{ell_mode} {k} {mode} {init_ok} False nan nan "
+                        f"forward_error:{exc!s} {n_nonsoc}"
+                    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/nonSOC/smoke_test_magnetic_model.py
+++ b/benchmarks/nonSOC/smoke_test_magnetic_model.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Generic init/forward smoke test for magnetic non-SOC MACE models."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import numpy as np
+import torch
+from e3nn import o3
+
+from mace import data, modules, tools
+from mace.tools import torch_geometric
+
+
+DEFAULT_MODEL = "MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE"
+DEFAULT_INTERACTION_FIRST = "RealAgnosticDensityInteractionBlock"
+DEFAULT_INTERACTION = "MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--interaction_first",
+        "--interaction-cls-first",
+        dest="interaction_first",
+        default=DEFAULT_INTERACTION_FIRST,
+    )
+    parser.add_argument(
+        "--interaction",
+        "--interaction-cls",
+        dest="interaction",
+        default=DEFAULT_INTERACTION,
+    )
+    parser.add_argument("--hidden-irreps", default="32x0e + 32x1o")
+    parser.add_argument("--mlp-irreps", default="16x0e")
+    parser.add_argument(
+        "--contraction_cls_first",
+        "--contraction-cls-first",
+        dest="contraction_cls_first",
+        default="SymmetricContraction",
+    )
+    parser.add_argument(
+        "--contraction_cls",
+        "--contraction-cls",
+        dest="contraction_cls",
+        default="NonSOCSymmetricContraction",
+    )
+    parser.add_argument("--num-interactions", type=int, default=2)
+    parser.add_argument("--correlation", type=int, default=3)
+    parser.add_argument("--r-max", type=float, default=4.5)
+    parser.add_argument("--num-bessel", type=int, default=10)
+    parser.add_argument("--num-polynomial-cutoff", type=int, default=5)
+    parser.add_argument("--max-ell", type=int, default=3)
+    parser.add_argument("--avg-num-neighbors", type=float, default=28.243721185921906)
+    parser.add_argument("--num-elements", type=int, default=2)
+    parser.add_argument("--atomic-numbers", default="1,8")
+    parser.add_argument("--atomic-energies", default="0.0,0.0")
+    parser.add_argument("--atomic-inter-scale", default="1.0")
+    parser.add_argument("--atomic-inter-shift", default="0.0")
+    parser.add_argument("--m-max", default="10.0,10.0")
+    parser.add_argument("--num-mag-radial-basis", type=int, default=8)
+    parser.add_argument("--num-mag-radial-basis-one-body", type=int, default=10)
+    parser.add_argument("--max-m-ell", type=int, default=3)
+    parser.add_argument("--distance-transform", default="Agnesi")
+    parser.add_argument("--cutoff", type=float, default=5.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--device", default="cpu")
+    return parser.parse_args()
+
+
+def parse_float_list(text: str) -> list[float]:
+    return [float(x.strip()) for x in text.split(",") if x.strip()]
+
+
+def parse_int_list(text: str) -> list[int]:
+    return [int(x.strip()) for x in text.split(",") if x.strip()]
+
+
+def build_batch(cutoff: float):
+    table = tools.AtomicNumberTable([1, 8])
+    config = data.Configuration(
+        atomic_numbers=np.array([8, 1, 1]),
+        positions=np.array(
+            [
+                [0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        ),
+        forces=np.zeros((3, 3), dtype=float),
+        energy=-1.5,
+        charges=np.array([-2.0, 1.0, 1.0]),
+        dipole=np.array([-1.5, 1.5, 2.0]),
+        magmom=np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, -2.0, 0.0],
+                [0.0, 0.0, -3.0],
+            ]
+        ),
+    )
+    atom_data = data.AtomicData.from_config(config, z_table=table, cutoff=cutoff)
+    loader = torch_geometric.dataloader.DataLoader([atom_data], batch_size=1)
+    return table, next(iter(loader))
+
+
+def build_model(args: argparse.Namespace, table: tools.AtomicNumberTable) -> torch.nn.Module:
+    model_cls = getattr(modules, args.model)
+    interaction_cls_first = modules.interaction_classes[args.interaction_first]
+    interaction_cls = modules.interaction_classes[args.interaction]
+    atomic_numbers = parse_int_list(args.atomic_numbers)
+    atomic_energies = np.array(parse_float_list(args.atomic_energies), dtype=float)
+    atomic_inter_scale = parse_float_list(args.atomic_inter_scale)
+    atomic_inter_shift = parse_float_list(args.atomic_inter_shift)
+    m_max = parse_float_list(args.m_max)
+
+    model_config: dict[str, Any] = dict(
+        r_max=args.r_max,
+        num_bessel=args.num_bessel,
+        num_polynomial_cutoff=args.num_polynomial_cutoff,
+        max_ell=args.max_ell,
+        interaction_cls_first=interaction_cls_first,
+        interaction_cls=interaction_cls,
+        num_interactions=args.num_interactions,
+        num_elements=args.num_elements,
+        hidden_irreps=o3.Irreps(args.hidden_irreps),
+        MLP_irreps=o3.Irreps(args.mlp_irreps),
+        gate=torch.nn.functional.silu,
+        atomic_energies=atomic_energies,
+        avg_num_neighbors=args.avg_num_neighbors,
+        atomic_numbers=atomic_numbers if atomic_numbers else table.zs,
+        correlation=args.correlation,
+        radial_type="bessel",
+        contraction_cls_first=args.contraction_cls_first,
+        contraction_cls=args.contraction_cls,
+        atomic_inter_scale=atomic_inter_scale,
+        atomic_inter_shift=atomic_inter_shift,
+        m_max=m_max,
+        num_mag_radial_basis=args.num_mag_radial_basis,
+        max_m_ell=args.max_m_ell,
+        num_mag_radial_basis_one_body=args.num_mag_radial_basis_one_body,
+        heads=["default"],
+        distance_transform=args.distance_transform,
+    )
+    return model_cls(**model_config)
+
+
+def main() -> None:
+    args = parse_args()
+
+    torch.set_default_dtype(torch.float64)
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    table, batch = build_batch(args.cutoff)
+    model = build_model(args, table).to(args.device)
+    batch_dict = {
+        key: value.to(args.device) if hasattr(value, "to") else value
+        for key, value in batch.to_dict().items()
+    }
+
+    outputs = model(
+        batch_dict,
+        training=False,
+        compute_force=True,
+        compute_stress=True,
+        compute_virials=True,
+        compute_magforces=True,
+    )
+
+    print("initialized=True")
+    print(f"model={args.model}")
+    print(f"interaction_first={args.interaction_first}")
+    print(f"interaction={args.interaction}")
+    print(f"hidden_irreps={args.hidden_irreps}")
+    print(f"contraction_cls_first={args.contraction_cls_first}")
+    print(f"contraction_cls={args.contraction_cls}")
+
+    nonsoc_modules = [
+        (name, mod)
+        for name, mod in model.named_modules()
+        if mod.__class__.__name__ == "NonSOCContraction"
+    ]
+    print(f"n_nonsoc_contractions={len(nonsoc_modules)}")
+    for name, mod in nonsoc_modules:
+        print(f"{name} irrep_out={mod.irrep_out} correlation={mod.correlation}")
+
+    for key in ("energy", "forces", "stress", "virials", "magforces", "node_feats"):
+        if key in outputs:
+            value = outputs[key]
+            shape = tuple(value.shape) if hasattr(value, "shape") else type(value)
+            print(f"{key}_shape={shape}")
+
+    if "energy" in outputs:
+        print(f"energy0={float(outputs['energy'][0])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mace/calculators/__init__.py
+++ b/mace/calculators/__init__.py
@@ -1,10 +1,10 @@
 from .foundations_models import mace_anicc, mace_mp, mace_off
 from .lammps_mace import LAMMPS_MACE
-from .mace import MACECalculator, MACEMagmomEqCalculator
+from .mace import MACECalculator, MagneticMACECalculator
 
 __all__ = [
     "MACECalculator",
-    "MACEMagmomEqCalculator",
+    "MagneticMACECalculator",
     "LAMMPS_MACE",
     "mace_mp",
     "mace_off",

--- a/mace/calculators/__init__.py
+++ b/mace/calculators/__init__.py
@@ -1,9 +1,10 @@
 from .foundations_models import mace_anicc, mace_mp, mace_off
 from .lammps_mace import LAMMPS_MACE
-from .mace import MACECalculator
+from .mace import MACECalculator, MACEMagmomEqCalculator
 
 __all__ = [
     "MACECalculator",
+    "MACEMagmomEqCalculator",
     "LAMMPS_MACE",
     "mace_mp",
     "mace_off",

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -63,6 +63,7 @@ class MACECalculator(Calculator):
         length_units_to_A: float = 1.0,
         default_dtype="",
         charges_key="Qs",
+        magmom_key="dft_magmom",
         model_type="MACE",
         compile_mode=None,
         fullgraph=True,
@@ -197,6 +198,7 @@ class MACECalculator(Calculator):
             [int(z) for z in self.models[0].atomic_numbers]
         )
         self.charges_key = charges_key
+        self.magmom_key = magmom_key
         try:
             self.heads = self.models[0].heads
         except AttributeError:
@@ -250,7 +252,7 @@ class MACECalculator(Calculator):
         return dict_of_tensors
 
     def _atoms_to_batch(self, atoms):
-        config = data.config_from_atoms(atoms, charges_key=self.charges_key)
+        config = data.config_from_atoms(atoms, charges_key=self.charges_key, magmom_key=self.magmom_key)
         data_loader = torch_geometric.dataloader.DataLoader(
             dataset=[
                 data.AtomicData.from_config(
@@ -290,6 +292,409 @@ class MACECalculator(Calculator):
             node_heads = batch["head"][batch["batch"]]
             num_atoms_arange = torch.arange(batch["positions"].shape[0])
             node_e0 = self.models[0].atomic_energies_fn(batch["node_attrs"])[
+                num_atoms_arange, node_heads
+            ]
+            compute_stress = not self.use_compile
+        else:
+            compute_stress = False
+
+        ret_tensors = self._create_result_tensors(
+            self.model_type, self.num_models, len(atoms)
+        )
+        for i, model in enumerate(self.models):
+            batch = self._clone_batch(batch_base)
+            out = model(
+                batch.to_dict(),
+                compute_stress=compute_stress,
+                training=self.use_compile,
+            )
+            if self.model_type in ["MACE", "EnergyDipoleMACE"]:
+                ret_tensors["energies"][i] = out["energy"].detach()
+                ret_tensors["node_energy"][i] = (out["node_energy"] - node_e0).detach()
+                ret_tensors["forces"][i] = out["forces"].detach()
+                if out["stress"] is not None:
+                    ret_tensors["stress"][i] = out["stress"].detach()
+            if self.model_type in ["DipoleMACE", "EnergyDipoleMACE"]:
+                ret_tensors["dipole"][i] = out["dipole"].detach()
+
+        self.results = {}
+        if self.model_type in ["MACE", "EnergyDipoleMACE"]:
+            self.results["energy"] = (
+                torch.mean(ret_tensors["energies"], dim=0).cpu().item()
+                * self.energy_units_to_eV
+            )
+            self.results["free_energy"] = self.results["energy"]
+            self.results["node_energy"] = (
+                torch.mean(ret_tensors["node_energy"], dim=0).cpu().numpy()
+            )
+            self.results["forces"] = (
+                torch.mean(ret_tensors["forces"], dim=0).cpu().numpy()
+                * self.energy_units_to_eV
+                / self.length_units_to_A
+            )
+            if self.num_models > 1:
+                self.results["energies"] = (
+                    ret_tensors["energies"].cpu().numpy() * self.energy_units_to_eV
+                )
+                self.results["energy_var"] = (
+                    torch.var(ret_tensors["energies"], dim=0, unbiased=False)
+                    .cpu()
+                    .item()
+                    * self.energy_units_to_eV
+                )
+                self.results["forces_comm"] = (
+                    ret_tensors["forces"].cpu().numpy()
+                    * self.energy_units_to_eV
+                    / self.length_units_to_A
+                )
+            if out["stress"] is not None:
+                self.results["stress"] = full_3x3_to_voigt_6_stress(
+                    torch.mean(ret_tensors["stress"], dim=0).cpu().numpy()
+                    * self.energy_units_to_eV
+                    / self.length_units_to_A**3
+                )
+                if self.num_models > 1:
+                    self.results["stress_var"] = full_3x3_to_voigt_6_stress(
+                        torch.var(ret_tensors["stress"], dim=0, unbiased=False)
+                        .cpu()
+                        .numpy()
+                        * self.energy_units_to_eV
+                        / self.length_units_to_A**3
+                    )
+        if self.model_type in ["DipoleMACE", "EnergyDipoleMACE"]:
+            self.results["dipole"] = (
+                torch.mean(ret_tensors["dipole"], dim=0).cpu().numpy()
+            )
+            if self.num_models > 1:
+                self.results["dipole_var"] = (
+                    torch.var(ret_tensors["dipole"], dim=0, unbiased=False)
+                    .cpu()
+                    .numpy()
+                )
+
+    def get_hessian(self, atoms=None):
+        if atoms is None and self.atoms is None:
+            raise ValueError("atoms not set")
+        if atoms is None:
+            atoms = self.atoms
+        if self.model_type != "MACE":
+            raise NotImplementedError("Only implemented for MACE models")
+        batch = self._atoms_to_batch(atoms)
+        hessians = [
+            model(
+                self._clone_batch(batch).to_dict(),
+                compute_hessian=True,
+                compute_stress=False,
+                training=self.use_compile,
+            )["hessian"]
+            for model in self.models
+        ]
+        hessians = [hessian.detach().cpu().numpy() for hessian in hessians]
+        if self.num_models == 1:
+            return hessians[0]
+        return hessians
+
+    def get_descriptors(self, atoms=None, invariants_only=True, num_layers=-1):
+        """Extracts the descriptors from MACE model.
+        :param atoms: ase.Atoms object
+        :param invariants_only: bool, if True only the invariant descriptors are returned
+        :param num_layers: int, number of layers to extract descriptors from, if -1 all layers are used
+        :return: np.ndarray (num_atoms, num_interactions, invariant_features) of invariant descriptors if num_models is 1 or list[np.ndarray] otherwise
+        """
+        if atoms is None and self.atoms is None:
+            raise ValueError("atoms not set")
+        if atoms is None:
+            atoms = self.atoms
+        if self.model_type != "MACE":
+            raise NotImplementedError("Only implemented for MACE models")
+        num_interactions = int(self.models[0].num_interactions)
+        if num_layers == -1:
+            num_layers = num_interactions
+        batch = self._atoms_to_batch(atoms)
+        descriptors = [model(batch.to_dict())["node_feats"] for model in self.models]
+
+        irreps_out = o3.Irreps(str(self.models[0].products[0].linear.irreps_out))
+        l_max = irreps_out.lmax
+        num_invariant_features = irreps_out.dim // (l_max + 1) ** 2
+        per_layer_features = [irreps_out.dim for _ in range(num_interactions)]
+        per_layer_features[-1] = (
+            num_invariant_features  # Equivariant features not created for the last layer
+        )
+
+        if invariants_only:
+            descriptors = [
+                extract_invariant(
+                    descriptor,
+                    num_layers=num_layers,
+                    num_features=num_invariant_features,
+                    l_max=l_max,
+                )
+                for descriptor in descriptors
+            ]
+        to_keep = np.sum(per_layer_features[:num_layers])
+        descriptors = [
+            descriptor[:, :to_keep].detach().cpu().numpy() for descriptor in descriptors
+        ]
+
+        if self.num_models == 1:
+            return descriptors[0]
+        return descriptors
+
+
+class MACEMagmomEqCalculator(Calculator):
+    """MACE ASE Calculator
+    args:
+        model_paths: str, path to model or models if a committee is produced
+                to make a committee use a wild card notation like mace_*.model
+        device: str, device to run on (cuda or cpu)
+        energy_units_to_eV: float, conversion factor from model energy units to eV
+        length_units_to_A: float, conversion factor from model length units to Angstroms
+        default_dtype: str, default dtype of model
+        charges_key: str, Array field of atoms object where atomic charges are stored
+        model_type: str, type of model to load
+                    Options: [MACE, DipoleMACE, EnergyDipoleMACE]
+
+    Dipoles are returned in units of Debye
+    """
+
+    def __init__(
+        self,
+        model_paths: Union[list, str, None] = None,
+        models: Union[List[torch.nn.Module], torch.nn.Module, None] = None,
+        device: str = "cpu",
+        energy_units_to_eV: float = 1.0,
+        length_units_to_A: float = 1.0,
+        default_dtype="",
+        charges_key="Qs",
+        magmom_key="dft_magmom",
+        model_type="MACE",
+        compile_mode=None,
+        fullgraph=True,
+        enable_cueq=False,
+        **kwargs,
+    ):
+        Calculator.__init__(self, **kwargs)
+        if enable_cueq:
+            assert model_type == "MACE", "CuEq only supports MACE models"
+            compile_mode = None
+        if "model_path" in kwargs:
+            deprecation_message = (
+                "'model_path' argument is deprecated, please use 'model_paths'"
+            )
+            if model_paths is None:
+                logging.warning(f"{deprecation_message} in the future.")
+                model_paths = kwargs["model_path"]
+            else:
+                raise ValueError(
+                    f"both 'model_path' and 'model_paths' given, {deprecation_message} only."
+                )
+
+        if (model_paths is None) == (models is None):
+            raise ValueError(
+                "Exactly one of 'model_paths' or 'models' must be provided"
+            )
+
+        self.results = {}
+
+        self.model_type = model_type
+
+        if model_type == "MACE":
+            self.implemented_properties = [
+                "energy",
+                "free_energy",
+                "node_energy",
+                "forces",
+                "stress",
+            ]
+        elif model_type == "DipoleMACE":
+            self.implemented_properties = ["dipole"]
+        elif model_type == "EnergyDipoleMACE":
+            self.implemented_properties = [
+                "energy",
+                "free_energy",
+                "node_energy",
+                "forces",
+                "stress",
+                "dipole",
+            ]
+        else:
+            raise ValueError(
+                f"Give a valid model_type: [MACE, DipoleMACE, EnergyDipoleMACE], {model_type} not supported"
+            )
+
+        if model_paths is not None:
+            if isinstance(model_paths, str):
+                # Find all models that satisfy the wildcard (e.g. mace_model_*.pt)
+                model_paths_glob = glob(model_paths)
+
+                if len(model_paths_glob) == 0:
+                    raise ValueError(f"Couldn't find MACE model files: {model_paths}")
+
+                model_paths = model_paths_glob
+            elif isinstance(model_paths, Path):
+                model_paths = [model_paths]
+
+            if len(model_paths) == 0:
+                raise ValueError("No mace file names supplied")
+            self.num_models = len(model_paths)
+
+            # Load models from files
+            self.models = [
+                torch.load(f=model_path, map_location=device)
+                for model_path in model_paths
+            ]
+            if enable_cueq:
+                print("Converting models to CuEq for acceleration")
+                self.models = [
+                    run_e3nn_to_cueq(model, device=device).to(device)
+                    for model in self.models
+                ]
+
+        elif models is not None:
+            if not isinstance(models, list):
+                models = [models]
+
+            if len(models) == 0:
+                raise ValueError("No models supplied")
+
+            self.models = models
+            self.num_models = len(models)
+
+        if self.num_models > 1:
+            print(f"Running committee mace with {self.num_models} models")
+
+            if model_type in ["MACE", "EnergyDipoleMACE"]:
+                self.implemented_properties.extend(
+                    ["energies", "energy_var", "forces_comm", "stress_var"]
+                )
+            elif model_type == "DipoleMACE":
+                self.implemented_properties.extend(["dipole_var"])
+
+        if compile_mode is not None:
+            print(f"Torch compile is enabled with mode: {compile_mode}")
+            self.models = [
+                torch.compile(
+                    prepare(extract_model)(model=model, map_location=device),
+                    mode=compile_mode,
+                    fullgraph=fullgraph,
+                )
+                for model in self.models
+            ]
+            self.use_compile = True
+        else:
+            self.use_compile = False
+
+        # Ensure all models are on the same device
+        for model in self.models:
+            model.to(device)
+
+        r_maxs = [model.magmom_mace.r_max.cpu() for model in self.models]
+        r_maxs = np.array(r_maxs)
+        if not np.all(r_maxs == r_maxs[0]):
+            raise ValueError(f"committee r_max are not all the same {' '.join(r_maxs)}")
+        self.r_max = float(r_maxs[0])
+
+        self.device = torch_tools.init_device(device)
+        self.energy_units_to_eV = energy_units_to_eV
+        self.length_units_to_A = length_units_to_A
+        self.z_table = utils.AtomicNumberTable(
+            [int(z) for z in self.models[0].magmom_mace.atomic_numbers]
+        )
+        self.charges_key = charges_key
+        self.magmom_key = magmom_key
+        try:
+            self.heads = self.models[0].heads
+        except AttributeError:
+            self.heads = ["Default"]
+        model_dtype = get_model_dtype(self.models[0])
+        if default_dtype == "":
+            print(
+                f"No dtype selected, switching to {model_dtype} to match model dtype."
+            )
+            default_dtype = model_dtype
+        if model_dtype != default_dtype:
+            print(
+                f"Default dtype {default_dtype} does not match model dtype {model_dtype}, converting models to {default_dtype}."
+            )
+            if default_dtype == "float64":
+                self.models = [model.double() for model in self.models]
+            elif default_dtype == "float32":
+                self.models = [model.float() for model in self.models]
+        torch_tools.set_default_dtype(default_dtype)
+        for model in self.models:
+            for param in model.parameters():
+                param.requires_grad = False
+
+    def _create_result_tensors(
+        self, model_type: str, num_models: int, num_atoms: int
+    ) -> dict:
+        """
+        Create tensors to store the results of the committee
+        :param model_type: str, type of model to load
+            Options: [MACE, DipoleMACE, EnergyDipoleMACE]
+        :param num_models: int, number of models in the committee
+        :return: tuple of torch tensors
+        """
+        dict_of_tensors = {}
+        if model_type in ["MACE", "EnergyDipoleMACE"]:
+            energies = torch.zeros(num_models, device=self.device)
+            node_energy = torch.zeros(num_models, num_atoms, device=self.device)
+            forces = torch.zeros(num_models, num_atoms, 3, device=self.device)
+            stress = torch.zeros(num_models, 3, 3, device=self.device)
+            dict_of_tensors.update(
+                {
+                    "energies": energies,
+                    "node_energy": node_energy,
+                    "forces": forces,
+                    "stress": stress,
+                }
+            )
+        if model_type in ["EnergyDipoleMACE", "DipoleMACE"]:
+            dipole = torch.zeros(num_models, 3, device=self.device)
+            dict_of_tensors.update({"dipole": dipole})
+        return dict_of_tensors
+
+    def _atoms_to_batch(self, atoms):
+        config = data.config_from_atoms(atoms, charges_key=self.charges_key, magmom_key=self.magmom_key)
+        data_loader = torch_geometric.dataloader.DataLoader(
+            dataset=[
+                data.AtomicData.from_config(
+                    config, z_table=self.z_table, cutoff=self.r_max, heads=self.heads
+                )
+            ],
+            batch_size=1,
+            shuffle=False,
+            drop_last=False,
+        )
+        batch = next(iter(data_loader)).to(self.device)
+        return batch
+
+    def _clone_batch(self, batch):
+        batch_clone = batch.clone()
+        if self.use_compile:
+            batch_clone["node_attrs"].requires_grad_(True)
+            batch_clone["positions"].requires_grad_(True)
+        return batch_clone
+
+    # pylint: disable=dangerous-default-value
+    def calculate(self, atoms=None, properties=None, system_changes=all_changes):
+        """
+        Calculate properties.
+        :param atoms: ase.Atoms object
+        :param properties: [str], properties to be computed, used by ASE internally
+        :param system_changes: [str], system changes since last calculation, used by ASE internally
+        :return:
+        """
+        # call to base-class to set atoms attribute
+        Calculator.calculate(self, atoms)
+
+        batch_base = self._atoms_to_batch(atoms)
+
+        if self.model_type in ["MACE", "EnergyDipoleMACE"]:
+            batch = self._clone_batch(batch_base)
+            node_heads = batch["head"][batch["batch"]]
+            num_atoms_arange = torch.arange(batch["positions"].shape[0])
+            node_e0 = self.models[0].magmom_mace.atomic_energies_fn(batch["node_attrs"])[
                 num_atoms_arange, node_heads
             ]
             compute_stress = not self.use_compile

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -287,7 +287,7 @@ class MACECalculator(Calculator):
 
         batch_base = self._atoms_to_batch(atoms)
 
-        if self.model_type in ["MACE", "EnergyDipoleMACE"]:
+        if self.model_type in ["MACE", "EnergyDipoleMACE",]:
             batch = self._clone_batch(batch_base)
             node_heads = batch["head"][batch["batch"]]
             num_atoms_arange = torch.arange(batch["positions"].shape[0])
@@ -441,7 +441,7 @@ class MACECalculator(Calculator):
         return descriptors
 
 
-class MACEMagmomEqCalculator(Calculator):
+class MagneticMACECalculator(Calculator):
     """MACE ASE Calculator
     args:
         model_paths: str, path to model or models if a committee is produced
@@ -842,3 +842,8 @@ class MACEMagmomEqCalculator(Calculator):
         if self.num_models == 1:
             return descriptors[0]
         return descriptors
+
+    def clean_cache_magmom(self,):
+        for model in self.models:
+            if hasattr(model, "cache_magmom"):
+                model.cache_magmom = None

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -810,13 +810,13 @@ class MagneticMACECalculator(Calculator):
             atoms = self.atoms
         if self.model_type != "MACE":
             raise NotImplementedError("Only implemented for MACE models")
-        num_interactions = int(self.models[0].num_interactions)
+        num_interactions = int(self.models[0].magmom_mace.num_interactions)
         if num_layers == -1:
             num_layers = num_interactions
         batch = self._atoms_to_batch(atoms)
         descriptors = [model(batch.to_dict())["node_feats"] for model in self.models]
 
-        irreps_out = o3.Irreps(str(self.models[0].products[0].linear.irreps_out))
+        irreps_out = o3.Irreps(str(self.models[0].magmom_mace.products[0].linear.irreps_out))
         l_max = irreps_out.lmax
         num_invariant_features = irreps_out.dim // (l_max + 1) ** 2
         per_layer_features = [irreps_out.dim for _ in range(num_interactions)]

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -740,7 +740,12 @@ class MagneticMACECalculator(Calculator):
                 ret_tensors["scf_steps"] = out["scf_steps"] # .detach()
             if "scf_energy_history" in out.keys():
                 ret_tensors["scf_energy_history"] = out["scf_energy_history"] # .detach()
-            
+            if "grad_history" in out.keys():
+                ret_tensors["grad_history"] = out["grad_history"]
+            if "grad_inf_history" in out.keys():
+                ret_tensors["grad_inf_history"] = out["grad_inf_history"]
+            if "step_inf_history" in out.keys():
+                ret_tensors["step_inf_history"] = out["step_inf_history"]
 
         self.results = {}
         if self.model_type in ["MACE", "EnergyDipoleMACE"]:
@@ -772,6 +777,15 @@ class MagneticMACECalculator(Calculator):
 
             if "one_body_magmom_energy" in ret_tensors.keys():
                 self.results['one_body_magmom_energy'] = ret_tensors["one_body_magmom_energy"].cpu().detach().numpy()
+
+            if "grad_history" in ret_tensors.keys():
+                self.results['grad_history'] = ret_tensors["grad_history"].cpu().numpy()
+
+            if "grad_inf_history" in ret_tensors.keys():
+                self.results['grad_inf_history'] = ret_tensors["grad_inf_history"].cpu().numpy()
+
+            if "step_inf_history" in ret_tensors.keys():
+                self.results['step_inf_history'] = ret_tensors["step_inf_history"].cpu().numpy()
 
             if self.num_models > 1:
                 assert 1 == 0

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -301,6 +301,7 @@ class MACECalculator(Calculator):
         ret_tensors = self._create_result_tensors(
             self.model_type, self.num_models, len(atoms)
         )
+
         for i, model in enumerate(self.models):
             batch = self._clone_batch(batch_base)
             out = model(
@@ -607,7 +608,6 @@ class MagneticMACECalculator(Calculator):
             self.heads = self.models[0].magmom_mace.heads
         except AttributeError:
             self.heads = ["Default"]
-        print(f"inside cal, {self.heads}")
         model_dtype = get_model_dtype(self.models[0])
         if default_dtype == "":
             print(
@@ -706,12 +706,18 @@ class MagneticMACECalculator(Calculator):
         ret_tensors = self._create_result_tensors(
             self.model_type, self.num_models, len(atoms)
         )
+
+        if "applied_B_field" in atoms.arrays.keys():
+            applied_B_field = torch.tensor(atoms.arrays['applied_B_field']).to(self.device)
+        else:
+            applied_B_field = None
         for i, model in enumerate(self.models):
             batch = self._clone_batch(batch_base)
             out = model(
                 batch.to_dict(),
                 compute_stress=compute_stress,
                 training=self.use_compile,
+                applied_B_field=applied_B_field,
             )
             if self.model_type in ["MACE", "EnergyDipoleMACE"]:
                 ret_tensors["energies"][i] = out["energy"].detach()
@@ -724,6 +730,17 @@ class MagneticMACECalculator(Calculator):
             if "equilibrated_magmom" in out.keys():
                 assert len(self.models) == 1, "magnetic mace committee not supported"
                 ret_tensors["dft_magmom"] = out["equilibrated_magmom"].detach()
+            if "magmom_history" in out.keys():
+                ret_tensors["magmom_history"] = out["magmom_history"].detach()
+            if "grad_norm_history" in out.keys():
+                ret_tensors["grad_norm_history"] = out["grad_norm_history"].detach()
+            if "one_body_magmom_energy" in out.keys():
+                ret_tensors["one_body_magmom_energy"] = out["one_body_magmom_energy"] # .detach()
+            if "scf_steps" in out.keys():
+                ret_tensors["scf_steps"] = out["scf_steps"] # .detach()
+            
+            
+                
 
         self.results = {}
         if self.model_type in ["MACE", "EnergyDipoleMACE"]:
@@ -740,11 +757,21 @@ class MagneticMACECalculator(Calculator):
                 * self.energy_units_to_eV
                 / self.length_units_to_A
             )
-            if "dft_magmom" in ret_tensors.keys():
-                #self.results['dft_magmom'] = torch.mean(ret_tensors["dft_magmom"], dim=0).cpu().numpy()
-                self.results['dft_magmom'] = ret_tensors["dft_magmom"].cpu().numpy()
             
+            if "dft_magmom" in ret_tensors.keys():
+                self.results['dft_magmom'] = ret_tensors["dft_magmom"].cpu().numpy()
+
+            if "magmom_history" in ret_tensors.keys():
+                self.results['magmom_history'] = ret_tensors["magmom_history"].cpu().numpy()
+
+            if "grad_norm_history" in ret_tensors.keys():
+                self.results['grad_norm_history'] = ret_tensors["grad_norm_history"].cpu().numpy()
+
+            if "one_body_magmom_energy" in ret_tensors.keys():
+                self.results['one_body_magmom_energy'] = ret_tensors["one_body_magmom_energy"].cpu().detach().numpy()
+
             if self.num_models > 1:
+                assert 1 == 0
                 self.results["energies"] = (
                     ret_tensors["energies"].cpu().numpy() * self.energy_units_to_eV
                 )
@@ -785,6 +812,15 @@ class MagneticMACECalculator(Calculator):
                 )
         # modify this inpalce
         atoms.arrays['dft_magmom'] = self.results["dft_magmom"]
+
+        if 'magmom_history' in self.results:
+            atoms.arrays['magmom_history'] = self.results["magmom_history"]
+
+        if 'grad_norm_history' in self.results:
+            atoms.info['grad_norm_history'] = self.results["grad_norm_history"]
+
+        if 'scf_steps' in ret_tensors:
+            atoms.info['scf_steps'] = ret_tensors["scf_steps"]
 
     def get_hessian(self, atoms=None):
         if atoms is None and self.atoms is None:

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -738,9 +738,9 @@ class MagneticMACECalculator(Calculator):
                 ret_tensors["one_body_magmom_energy"] = out["one_body_magmom_energy"] # .detach()
             if "scf_steps" in out.keys():
                 ret_tensors["scf_steps"] = out["scf_steps"] # .detach()
+            if "scf_energy_history" in out.keys():
+                ret_tensors["scf_energy_history"] = out["scf_energy_history"] # .detach()
             
-            
-                
 
         self.results = {}
         if self.model_type in ["MACE", "EnergyDipoleMACE"]:
@@ -758,6 +758,9 @@ class MagneticMACECalculator(Calculator):
                 / self.length_units_to_A
             )
             
+            if "scf_energy_history" in ret_tensors.keys():
+                self.results['scf_energy_history'] = ret_tensors["scf_energy_history"].cpu().numpy()
+
             if "dft_magmom" in ret_tensors.keys():
                 self.results['dft_magmom'] = ret_tensors["dft_magmom"].cpu().numpy()
 
@@ -813,8 +816,11 @@ class MagneticMACECalculator(Calculator):
         # modify this inpalce
         atoms.arrays['dft_magmom'] = self.results["dft_magmom"]
 
+        if 'scf_energy_history' in self.results:
+            atoms.info['scf_energy_history'] = self.results["scf_energy_history"]
+
         if 'magmom_history' in self.results:
-            atoms.arrays['magmom_history'] = self.results["magmom_history"]
+            atoms.info['magmom_history'] = self.results["magmom_history"]
 
         if 'grad_norm_history' in self.results:
             atoms.info['grad_norm_history'] = self.results["grad_norm_history"]

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -602,10 +602,12 @@ class MagneticMACECalculator(Calculator):
         )
         self.charges_key = charges_key
         self.magmom_key = magmom_key
+        
         try:
-            self.heads = self.models[0].heads
+            self.heads = self.models[0].magmom_mace.heads
         except AttributeError:
             self.heads = ["Default"]
+        print(f"inside cal, {self.heads}")
         model_dtype = get_model_dtype(self.models[0])
         if default_dtype == "":
             print(

--- a/mace/cli/convert_cueq_e3nn.py
+++ b/mace/cli/convert_cueq_e3nn.py
@@ -34,6 +34,7 @@ def get_transfer_keys(num_layers: int) -> List[str]:
             for s in [
                 f"interactions.{j}.magmom_linear.weight",
                 f"interactions.{j}.magmom_skip_tp.weight",
+                f"products.{j}.linear_ori.weight",
             ]
     ]
 

--- a/mace/cli/convert_cueq_e3nn.py
+++ b/mace/cli/convert_cueq_e3nn.py
@@ -28,11 +28,23 @@ def get_transfer_keys() -> List[str]:
             f"interactions.{j}.skip_tp.weight",
             f"products.{j}.linear.weight",
         ]
+    ] + [
+        s
+        for j in range(2)
+            for s in [
+                f"interactions.{j}.magmom_linear.weight",
+                f"interactions.{j}.magmom_skip_tp.weight",
+            ]
     ]
 
 
-def get_kmax_pairs(max_L: int, correlation: int) -> List[Tuple[int, int]]:
+def get_kmax_pairs(max_L: int, correlation: int, num_interactions: int) -> List[Tuple[int, int]]:
     """Determine kmax pairs based on max_L and correlation"""
+    if num_interactions == 1:
+        if correlation == 2:
+            raise NotImplementedError("Correlation 2 not supported yet")    
+        else:
+            return [[0, max_L]]
     if correlation == 2:
         raise NotImplementedError("Correlation 2 not supported yet")
     if correlation == 3:
@@ -45,9 +57,10 @@ def transfer_symmetric_contractions(
     target_dict: Dict[str, torch.Tensor],
     max_L: int,
     correlation: int,
+    num_interactions: int,
 ):
     """Transfer symmetric contraction weights from CuEq to E3nn format"""
-    kmax_pairs = get_kmax_pairs(max_L, correlation)
+    kmax_pairs = get_kmax_pairs(max_L, correlation, num_interactions)
 
     for i, kmax in kmax_pairs:
         # Get the combined weight tensor from source
@@ -84,6 +97,7 @@ def transfer_weights(
     target_model: torch.nn.Module,
     max_L: int,
     correlation: int,
+    num_interactions: int,
 ):
     """Transfer weights from CuEq to E3nn format"""
     # Get state dicts
@@ -99,7 +113,7 @@ def transfer_weights(
             logging.warning(f"Key {key} not found in source model")
 
     # Transfer symmetric contractions
-    transfer_symmetric_contractions(source_dict, target_dict, max_L, correlation)
+    transfer_symmetric_contractions(source_dict, target_dict, max_L, correlation, num_interactions)
 
     # Unsqueeze linear and skip_tp layers
     for key in source_dict.keys():
@@ -125,7 +139,7 @@ def transfer_weights(
                 )
 
     # Transfer avg_num_neighbors
-    for i in range(2):
+    for i in range(num_interactions):
         target_model.interactions[i].avg_num_neighbors = source_model.interactions[
             i
         ].avg_num_neighbors
@@ -149,6 +163,7 @@ def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True
     # Get max_L and correlation from config
     max_L = config["hidden_irreps"].lmax
     correlation = config["correlation"]
+    num_interactions = config["num_interactions"]
 
     # Remove CuEq config
     config.pop("cueq_config", None)
@@ -158,7 +173,7 @@ def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True
     target_model = source_model.__class__(**config)
 
     # Transfer weights with proper remapping
-    transfer_weights(source_model, target_model, max_L, correlation)
+    transfer_weights(source_model, target_model, max_L, correlation, num_interactions)
 
     if return_model:
         return target_model

--- a/mace/cli/convert_cueq_e3nn.py
+++ b/mace/cli/convert_cueq_e3nn.py
@@ -169,6 +169,11 @@ def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True
     # Remove CuEq config
     config.pop("cueq_config", None)
 
+    if "Magnetic" not in str(source_model.__class__):
+        config.pop("m_max", None)
+        config.pop("max_m_ell", None)
+        config.pop("num_mag_radial_basis", None)
+
     # Create new model without CuEq config
     logging.info("Creating new model without CuEq settings")
     target_model = source_model.__class__(**config)

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -9,19 +9,20 @@ from mace.modules.wrapper_ops import CuEquivarianceConfig
 from mace.tools.scripts_utils import extract_config_mace_model
 
 
-def get_transfer_keys() -> List[str]:
+def get_transfer_keys(num_layers: int) -> List[str]:
     """Get list of keys that need to be transferred"""
     return [
         "node_embedding.linear.weight",
         "radial_embedding.bessel_fn.bessel_weights",
         "atomic_energies_fn.atomic_energies",
         "readouts.0.linear.weight",
+        *[f"readouts.{j}.linear.weight" for j in range(num_layers - 1)],
         "scale_shift.scale",
         "scale_shift.shift",
-        *[f"readouts.1.linear_{i}.weight" for i in range(1, 3)],
+        *[f"readouts.{num_layers-1}.linear_{i}.weight" for i in range(1, 3)],
     ] + [
         s
-        for j in range(2)
+        for j in range(num_layers)
         for s in [
             f"interactions.{j}.linear_up.weight",
             *[f"interactions.{j}.conv_tp_weights.layer{i}.weight" for i in range(4)],
@@ -31,7 +32,7 @@ def get_transfer_keys() -> List[str]:
         ]
     ] + [
         s
-        for j in range(2)
+        for j in range(num_layers)
             for s in [
                 f"interactions.{j}.magmom_linear.weight",
                 f"interactions.{j}.magmom_skip_tp.weight",
@@ -39,28 +40,28 @@ def get_transfer_keys() -> List[str]:
     ]
 
 
-def get_kmax_pairs(max_L: int, correlation: int, num_interactions: int) -> List[Tuple[int, int]]:
+def get_kmax_pairs(
+    max_L: int, correlation: int, num_layers: int
+) -> List[Tuple[int, int]]:
     """Determine kmax pairs based on max_L and correlation"""
-    if num_interactions == 1:
-        if correlation == 2:
-            raise NotImplementedError("Correlation 2 not supported yet")    
-        else:
-            return [[0, max_L]]
     if correlation == 2:
         raise NotImplementedError("Correlation 2 not supported yet")
     if correlation == 3:
-        return [[0, max_L], [1, 0]]
+        kmax_pairs = [[i, max_L] for i in range(num_layers - 1)]
+        kmax_pairs = kmax_pairs + [[num_layers - 1, 0]]
+        return kmax_pairs
     raise NotImplementedError(f"Correlation {correlation} not supported")
+
 
 def transfer_symmetric_contractions(
     source_dict: Dict[str, torch.Tensor],
     target_dict: Dict[str, torch.Tensor],
     max_L: int,
     correlation: int,
-    num_interactions: int,
+    num_layers: int,
 ):
     """Transfer symmetric contraction weights"""
-    kmax_pairs = get_kmax_pairs(max_L, correlation, num_interactions)
+    kmax_pairs = get_kmax_pairs(max_L, correlation, num_layers)
 
     for i, kmax in kmax_pairs:
         wm = torch.concatenate(
@@ -81,7 +82,7 @@ def transfer_weights(
     target_model: torch.nn.Module,
     max_L: int,
     correlation: int,
-    num_interactions: int,
+    num_layers: int,
 ):
     """Transfer weights with proper remapping"""
     # Get source state dict
@@ -89,7 +90,7 @@ def transfer_weights(
     target_dict = target_model.state_dict()
 
     # Transfer main weights
-    transfer_keys = get_transfer_keys()
+    transfer_keys = get_transfer_keys(num_layers)
     for key in transfer_keys:
         if key in source_dict:  # Check if key exists
             target_dict[key] = source_dict[key]
@@ -97,7 +98,7 @@ def transfer_weights(
             logging.warning(f"Key {key} not found in source model")
 
     # Transfer symmetric contractions
-    transfer_symmetric_contractions(source_dict, target_dict, max_L, correlation, num_interactions)
+    transfer_symmetric_contractions(source_dict, target_dict, max_L, correlation, num_layers)
 
     # Unsqueeze linear and skip_tp layers
     for key in source_dict.keys():
@@ -120,7 +121,7 @@ def transfer_weights(
                     f"source {source_dict[key].shape} vs target {target_dict[key].shape}"
                 )
     # Transfer avg_num_neighbors
-    for i in range(num_interactions):
+    for i in range(num_layers):
         target_model.interactions[i].avg_num_neighbors = source_model.interactions[
             i
         ].avg_num_neighbors
@@ -152,7 +153,7 @@ def run(
     # Get max_L and correlation from config
     max_L = config["hidden_irreps"].lmax
     correlation = config["correlation"]
-    num_interactions = config["num_interactions"]
+    num_layers = config["num_interactions"]
 
     # Add cuequivariance config
     config["cueq_config"] = CuEquivarianceConfig(
@@ -167,7 +168,7 @@ def run(
     target_model = source_model.__class__(**config).to(device)
 
     # Transfer weights with proper remapping
-    transfer_weights(source_model, target_model, max_L, correlation, num_interactions)
+    transfer_weights(source_model, target_model, max_L, correlation, num_layers)
 
     if return_model:
         return target_model

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -36,6 +36,7 @@ def get_transfer_keys(num_layers: int) -> List[str]:
             for s in [
                 f"interactions.{j}.magmom_linear.weight",
                 f"interactions.{j}.magmom_skip_tp.weight",
+                f"products.{j}.linear_ori.weight",
             ]
     ]
 

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -29,6 +29,7 @@ def get_transfer_keys(num_layers: int) -> List[str]:
             f"interactions.{j}.linear.weight",
             f"interactions.{j}.skip_tp.weight",
             f"products.{j}.linear.weight",
+            f"magmom_products.{j}.linear.weight",
         ]
     ] + [
         s
@@ -37,6 +38,7 @@ def get_transfer_keys(num_layers: int) -> List[str]:
                 f"interactions.{j}.magmom_linear.weight",
                 f"interactions.{j}.magmom_skip_tp.weight",
                 f"products.{j}.linear_ori.weight",
+                f"magmom_products.{j}.linear_ori.weight",
             ]
     ]
 
@@ -106,11 +108,17 @@ def transfer_weights(
         if any(x in key for x in ["linear", "skip_tp"]) and "weight" in key:
             target_dict[key] = target_dict[key].unsqueeze(0)
 
+
     transferred_keys = set(transfer_keys)
     remaining_keys = (
         set(source_dict.keys()) & set(target_dict.keys()) - transferred_keys
     )
     remaining_keys = {k for k in remaining_keys if "symmetric_contraction" not in k}
+
+    for key in remaining_keys:
+        if key == "magmom_products.0.conv_tp.weight" or key == "products.0.conv_tp.weight":
+            target_dict[key] = target_dict[key]# .unsqueeze(0)
+
     if remaining_keys:
         for key in remaining_keys:
             if source_dict[key].shape == target_dict[key].shape:

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -164,6 +164,12 @@ def run(
         optimize_all=True,
     )
 
+    # remove magnetic model configuration if the model is not 
+    # for magnetism
+    if "Magnetic" not in str(source_model.__class__):
+        config.pop("m_max", None)
+        config.pop("max_m_ell", None)
+        config.pop("num_mag_radial_basis", None)
     # Create new model with cuequivariance config
     logging.info("Creating new model with cuequivariance settings")
     target_model = source_model.__class__(**config).to(device)

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -48,8 +48,10 @@ def get_kmax_pairs(
 ) -> List[Tuple[int, int]]:
     """Determine kmax pairs based on max_L and correlation"""
     if correlation == 2:
-        raise NotImplementedError("Correlation 2 not supported yet")
-    if correlation == 3:
+        raise NotImplementedError("Correlation 2 not supported yet")    
+    if num_layers == 1:
+        return [[i, max_L] for i in range(num_layers)]
+    elif correlation == 3:
         kmax_pairs = [[i, max_L] for i in range(num_layers - 1)]
         kmax_pairs = kmax_pairs + [[num_layers - 1, 0]]
         return kmax_pairs

--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -93,7 +93,7 @@ def run(args: argparse.Namespace) -> None:
     if args.head is not None:
         for atoms in atoms_list:
             atoms.info["head"] = args.head
-    configs = [data.config_from_atoms(atoms) for atoms in atoms_list]
+    configs = [data.config_from_atoms(atoms, magmom_key = 'dft_magmom') for atoms in atoms_list]
 
     z_table = utils.AtomicNumberTable([int(z) for z in model.atomic_numbers])
 

--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -13,7 +13,7 @@ import torch
 
 from mace import data
 from mace.tools import torch_geometric, torch_tools, utils
-
+from tqdm import tqdm
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -128,7 +128,7 @@ def run(args: argparse.Namespace) -> None:
     forces_collection = []
     magforces_collection = []
 
-    for batch in data_loader:
+    for batch in tqdm(data_loader):
         batch = batch.to(device)
         output = model(batch.to_dict(), compute_stress=args.compute_stress)
         energies_list.append(torch_tools.to_numpy(output["energy"]))

--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -67,6 +67,13 @@ def parse_args() -> argparse.Namespace:
         required=False,
         default=None,
     )
+    parser.add_argument(
+        "--magmom_key",
+        help="key for getting magnetic moment",
+        type=str,
+        required=True,
+        default=None,
+    )
     return parser.parse_args()
 
 
@@ -93,7 +100,7 @@ def run(args: argparse.Namespace) -> None:
     if args.head is not None:
         for atoms in atoms_list:
             atoms.info["head"] = args.head
-    configs = [data.config_from_atoms(atoms, magmom_key = 'dft_magmom') for atoms in atoms_list]
+    configs = [data.config_from_atoms(atoms, magmom_key = args.magmom_key) for atoms in atoms_list]
 
     z_table = utils.AtomicNumberTable([int(z) for z in model.atomic_numbers])
 

--- a/mace/cli/fine_tuning_select.py
+++ b/mace/cli/fine_tuning_select.py
@@ -11,7 +11,8 @@ import ase.io
 import numpy as np
 import torch
 
-from mace.calculators import MACECalculator, mace_mp
+from mace.calculators import MACECalculator, MagneticMACECalculator, mace_mp
+from mace.modules import MagneticSCFMACE
 
 try:
     import fpsample
@@ -99,6 +100,18 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=1.0,
     )
+    parser.add_argument(
+        "--magmom_key_pt",
+        help="mangetic moment key, needed for magnetic MACE to rewrite magmom as dft_magmom to be used by calc",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--magmom_key_ft",
+        help="mangetic moment key, needed for magnetic MACE to rewrite magmom as dft_magmom to be used by calc",
+        type=str,
+        default=None,
+    )
     parser.add_argument("--seed", help="random seed", type=int, default=42)
     return parser.parse_args()
 
@@ -114,6 +127,11 @@ def calculate_descriptors(atoms: List[ase.Atoms], calc: MACECalculator) -> None:
         }
         mol.info["mace_descriptors"] = descriptors_dict
 
+def init_magnetic_mace_wrapper(PATH, device="cpu", default_dtype="float64"):
+    model = torch.load(PATH, map_location = device, weights_only = False).to(device)
+    magmom_maceeq = MagneticSCFMACE(model, use_scf=False)
+    calc = MagneticMACECalculator(models = [magmom_maceeq,], device = device, default_dtype=default_dtype)
+    return calc
 
 def filter_atoms(
     atoms: ase.Atoms, element_subset: List[str], filtering_type: str
@@ -202,6 +220,17 @@ class FPS:
                     descriptors[z]
                 ).astype(np.float32)
 
+def set_magmom(ats, magmom_key = None):
+    N_configs = len(ats)
+    have_magmom = 0
+    if magmom_key == None:
+        return ats
+    else:
+        for at in ats:
+            at.arrays['dft_magmom'] = at.arrays[magmom_key]
+            have_magmom += 1
+    print(f"Found magnetic moment in {have_magmom} number of configs in {N_configs}.")
+    return ats
 
 def select_samples(
     args: argparse.Namespace,
@@ -211,15 +240,20 @@ def select_samples(
     if args.model in ["small", "medium", "large"]:
         calc = mace_mp(args.model, device=args.device, default_dtype=args.default_dtype)
     else:
-        calc = MACECalculator(
-            model_paths=args.model, device=args.device, default_dtype=args.default_dtype
-        )
+        if args.magmom_key_ft != None and args.magmom_key_pt != None:
+            calc = init_magnetic_mace_wrapper(args.model, device = args.device, default_dtype=args.default_dtype)
+        else:
+            calc = MACECalculator(
+                model_paths=args.model, device=args.device, default_dtype=args.default_dtype
+            )
     if isinstance(args.configs_ft, str):
         atoms_list_ft = ase.io.read(args.configs_ft, index=":")
+        atoms_list_ft = set_magmom(atoms_list_ft, args.magmom_key_ft)
     else:
         atoms_list_ft = []
         for path in args.configs_ft:
-            atoms_list_ft += ase.io.read(path, index=":")
+            atoms_list_ft += set_magmom(ase.io.read(path, index=":"), args.magmom_key_ft)
+            
 
     if args.filtering_type is not None:
         all_species_ft = np.unique([x.symbol for atoms in atoms_list_ft for x in atoms])
@@ -262,7 +296,7 @@ def select_samples(
             atoms_list_pt = atoms_list_pt_filtered
 
     else:
-        atoms_list_pt = ase.io.read(args.configs_pt, index=":")
+        atoms_list_pt = set_magmom(ase.io.read(args.configs_pt, index=":"), magmom_key=args.magmom_key_pt)
         if args.descriptors is not None:
             logging.info(
                 f"Loading descriptors for the pretraining set from {args.descriptors}"

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -252,6 +252,7 @@ def run(args) -> None:
             config_type_weights = get_config_type_weights(
                 head_config.config_type_weights
             )
+
             collections, atomic_energies_dict = get_dataset_from_xyz(
                 work_dir=args.work_dir,
                 train_path=train_files_ase_list,
@@ -266,9 +267,12 @@ def run(args) -> None:
                 virials_key=head_config.virials_key,
                 dipole_key=head_config.dipole_key,
                 charges_key=head_config.charges_key,
+                magmom_key=head_config.magmom_key,
+                magforces_key=head_config.magforces_key,
                 head_name=head_config.head_name,
                 keep_isolated_atoms=head_config.keep_isolated_atoms,
             )
+            
             head_config.collections = SubsetCollection(
                 train=collections.train,
                 valid=collections.valid,

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -862,6 +862,8 @@ def run(args) -> None:
         plotter=plotter,
         train_sampler=train_sampler,
         rank=rank,
+        # whether to do data augmnetation with magenticmoment
+        data_aug_magmom=args.data_aug_magmom,
     )
 
     logging.info("")

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -707,7 +707,7 @@ def run(args) -> None:
     # Model
     model, output_args = configure_model(args, train_loader, atomic_energies, model_foundation, heads, z_table, head_configs)
     model.to(device)
-
+    print("output_args: ", output_args)
     logging.debug(model)
     logging.info(f"Total number of parameters: {tools.count_parameters(model)}")
     logging.info("")

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -721,7 +721,7 @@ def run(args) -> None:
     # Cueq
     if args.enable_cueq:
         logging.info("Converting model to CUEQ for accelerated training")
-        assert model.__class__.__name__ in ["MACE", "ScaleShiftMACE"]
+        #assert model.__class__.__name__ in ["MACE", "ScaleShiftMACE"]
         model = run_e3nn_to_cueq(deepcopy(model), device=device)
     # Optimizer
     param_options = get_params_options(args, model)

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -340,10 +340,11 @@ def run(args) -> None:
             pt_virials_key = args.pt_virials_key or args.virials_key
             pt_dipole_key = args.pt_dipole_key or args.dipole_key
             pt_charges_key = args.pt_charges_key or args.charges_key
+            pt_magmom_key = args.pt_magmom_key or args.magmom_key
 
             logging.info(
                 f"Using the following keys for pt_head: energy={pt_energy_key}, forces={pt_forces_key}, "
-                f"stress={pt_stress_key}, virials={pt_virials_key}, dipole={pt_dipole_key}, charges={pt_charges_key}"
+                f"stress={pt_stress_key}, virials={pt_virials_key}, dipole={pt_dipole_key}, charges={pt_charges_key}, magmom={pt_magmom_key}"
             )
 
             # Normalize file paths
@@ -369,6 +370,7 @@ def run(args) -> None:
                 virials_key=pt_virials_key,
                 dipole_key=pt_dipole_key,
                 charges_key=pt_charges_key,
+                magmom_key=pt_magmom_key,
                 keep_isolated_atoms=args.keep_isolated_atoms,
                 avg_num_neighbors=model_foundation.interactions[0].avg_num_neighbors,
                 compute_avg_num_neighbors=False,
@@ -390,6 +392,7 @@ def run(args) -> None:
                     virials_key=pt_virials_key,
                     dipole_key=pt_dipole_key,
                     charges_key=pt_charges_key,
+                    magmom_key=pt_magmom_key,
                     head_name="pt_head",
                     keep_isolated_atoms=args.keep_isolated_atoms,
                 )

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -802,7 +802,7 @@ def run(args) -> None:
     if args.wandb:
         setup_wandb(args)
     if args.distributed:
-        distributed_model = DDP(model, device_ids=[local_rank])
+        distributed_model = DDP(model, device_ids=[local_rank], find_unused_parameters=True,)
     else:
         distributed_model = None
 

--- a/mace/cli/run_train_onebody.py
+++ b/mace/cli/run_train_onebody.py
@@ -1054,12 +1054,7 @@ def run(args) -> None:
     E1  = torch.stack(E1_list)   # (n_species,)
     E2  = torch.stack(E2_list)   # (n_species,)
 
-    model.saturation = EvenMagSaturationBarrier(
-        m_max=torch.as_tensor(np.array(args.m_max)/np.array(args.prefactor), device=device, dtype=E0.dtype),
-        E2=E2.to(device),
-        E1=E1.to(device),
-        prefactor=args.prefactor
-    ).to(device)
+    model.saturation = EvenMagSaturationBarrier(m_max=torch.as_tensor(np.array(args.m_max)/np.array(args.prefactor), device=device, dtype=E0.dtype),E2=E2.to(device),E1=E1.to(device),prefactor=args.prefactor).to(device)
     
     checkpoint_handler.save(state=CheckpointState(model, optimizer, lr_scheduler), epochs=0, keep_last=True,)
     model_path = Path(args.checkpoints_dir) / (tag + ".model")

--- a/mace/cli/run_train_onebody.py
+++ b/mace/cli/run_train_onebody.py
@@ -1,0 +1,1070 @@
+###########################################################################################
+# Training script for MACE
+# Authors: Ilyes Batatia, Gregor Simm, David Kovacs
+# This program is distributed under the MIT License (see MIT.md)
+###########################################################################################
+
+import ast
+import glob
+import json
+import logging
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import List, Optional
+
+import torch.distributed
+import torch.nn.functional
+from e3nn.util import jit
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.optim import LBFGS
+from torch.utils.data import ConcatDataset
+from torch_ema import ExponentialMovingAverage
+
+import mace
+from mace import data, tools
+from mace.calculators.foundations_models import mace_mp, mace_off
+from mace.cli.convert_cueq_e3nn import run as run_cueq_to_e3nn
+from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
+from mace.cli.visualise_train import TrainingPlotter
+from mace.tools import torch_geometric
+from mace.tools.model_script_utils import configure_model
+from mace.tools.multihead_tools import (
+    HeadConfig,
+    assemble_mp_data,
+    dict_head_to_dataclass,
+    prepare_default_head,
+)
+from mace.tools.run_train_utils import (
+    combine_datasets,
+    load_dataset_for_path,
+    normalize_file_paths,
+)
+from mace.tools.scripts_utils import (
+    LRScheduler,
+    SubsetCollection,
+    check_path_ase_read,
+    convert_to_json_format,
+    dict_to_array,
+    extract_config_mace_model,
+    get_atomic_energies,
+    get_avg_num_neighbors,
+    get_config_type_weights,
+    get_dataset_from_xyz,
+    get_files_with_suffix,
+    get_loss_fn,
+    get_optimizer,
+    get_params_options,
+    get_swa,
+    print_git_commit,
+    remove_pt_head,
+    setup_wandb,
+)
+from mace.tools.slurm_distributed import DistributedEnvironment
+from mace.tools.tables_utils import create_error_table
+from mace.tools.utils import AtomicNumberTable
+from mace.tools.checkpoint import CheckpointState
+from mace.modules.models import EvenMagSaturationBarrier
+from mace.modules.models import natural_cubic_spline_coeffs, cubic_spline_eval
+
+def main() -> None:
+    """
+    This script runs the training/fine tuning for mace
+    """
+    args = tools.build_default_arg_parser().parse_args()
+    run(args)
+
+
+from collections import defaultdict
+import numpy as np
+
+def collect_magmom_energy(loader):
+    """
+    Returns:
+        data[element] = {
+            "m": np.ndarray of |m|,
+            "E": np.ndarray of per-atom energies
+        }
+    """
+    data = defaultdict(lambda: {"m": [], "E": []})
+
+    for batch in loader:
+        # expected shapes:
+        # magmoms: (N_atoms,)
+        # atomic_numbers: (N_atoms,)
+        # energy: (N_structures,)
+        # batch.atom_ptr or batch.batch maps atoms -> structure
+
+        mag = batch.magmom.detach().cpu().numpy()
+        elem_idx = batch.node_attrs.argmax(dim=1).detach().cpu().numpy()
+        E   = batch.energy.detach().cpu().numpy()
+
+        # map atoms to structures
+        atom2struct = batch.batch.detach().cpu().numpy()
+        natoms_per_struct = np.bincount(atom2struct)
+
+        # per-atom energy (uniform partition)
+        E_atom = E[atom2struct] / natoms_per_struct[atom2struct]
+
+        for mi, zi, ei in zip(mag, elem_idx, E_atom):
+            data[int(zi)]["m"].append(abs(mi))
+            data[int(zi)]["E"].append(ei)
+
+    # convert to arrays
+    for z in data:
+        data[z]["m"] = np.asarray(data[z]["m"])
+        data[z]["E"] = np.asarray(data[z]["E"])
+
+    return data
+
+def init_even_spline_interp(
+    Ms,        # |m| values, 1D torch tensor
+    Es,        # per-atom energies, 1D torch tensor
+    u_knots,       # spline knot positions (|m| grid), torch tensor
+    dtype,
+):
+    """
+    Returns y_init suitable for model.E_m_spline.y[element]
+    """
+
+    m_ref = torch.tensor(Ms, dtype=dtype)
+    E_ref = torch.tensor(Es, dtype=dtype)
+
+    u_ref = m_ref**2
+    u_sorted, idx = torch.sort(u_ref)
+    E_sorted = E_ref[idx]
+
+    assert u_sorted.max().item() == u_knots[-1].item()
+
+    # numpy interpolation (stable + simple)
+    y_init = torch.tensor(
+        np.interp(u_knots.detach().cpu().numpy(),u_sorted.detach().cpu().numpy(),E_sorted.detach().cpu().numpy(),),
+        dtype=dtype,
+        device=u_knots.device,
+    )
+
+    # hard physical constraint
+    y_init[0] = 0.0  # enforce E(|m|=0) = 0
+
+    return y_init
+
+def run(args) -> None:
+    """
+    This script runs the training/fine tuning for mace
+    """
+    tag = tools.get_tag(name=args.name, seed=args.seed)
+    args, input_log_messages = tools.check_args(args)
+
+    if args.device == "xpu":
+        try:
+            import intel_extension_for_pytorch as ipex
+        except ImportError as e:
+            raise ImportError(
+                "Error: Intel extension for PyTorch not found, but XPU device was specified"
+            ) from e
+    if args.distributed:
+        try:
+            distr_env = DistributedEnvironment()
+        except Exception as e:  # pylint: disable=W0703
+            logging.error(f"Failed to initialize distributed environment: {e}")
+            return
+        world_size = distr_env.world_size
+        local_rank = distr_env.local_rank
+        rank = distr_env.rank
+        if rank == 0:
+            print(distr_env)
+        torch.distributed.init_process_group(backend="nccl")
+    else:
+        rank = int(0)
+
+    # Setup
+    tools.set_seeds(args.seed)
+    tools.setup_logger(level=args.log_level, tag=tag, directory=args.log_dir, rank=rank)
+    logging.info("===========VERIFYING SETTINGS===========")
+    for message, loglevel in input_log_messages:
+        logging.log(level=loglevel, msg=message)
+
+    if args.distributed:
+        torch.cuda.set_device(local_rank)
+        logging.info(f"Process group initialized: {torch.distributed.is_initialized()}")
+        logging.info(f"Processes: {world_size}")
+
+    try:
+        logging.info(f"MACE version: {mace.__version__}")
+    except AttributeError:
+        logging.info("Cannot find MACE version, please install MACE via pip")
+    logging.debug(f"Configuration: {args}")
+
+    tools.set_default_dtype(args.default_dtype)
+    device = tools.init_device(args.device)
+    commit = print_git_commit()
+    model_foundation: Optional[torch.nn.Module] = None
+    if args.foundation_model is not None:
+        if args.foundation_model in ["small", "medium", "large"]:
+            logging.info(
+                f"Using foundation model mace-mp-0 {args.foundation_model} as initial checkpoint."
+            )
+            calc = mace_mp(
+                model=args.foundation_model,
+                device=args.device,
+                default_dtype=args.default_dtype,
+            )
+            model_foundation = calc.models[0]
+        elif args.foundation_model in ["small_off", "medium_off", "large_off"]:
+            model_type = args.foundation_model.split("_")[0]
+            logging.info(
+                f"Using foundation model mace-off-2023 {model_type} as initial checkpoint. ASL license."
+            )
+            calc = mace_off(
+                model=model_type,
+                device=args.device,
+                default_dtype=args.default_dtype,
+            )
+            model_foundation = calc.models[0]
+        else:
+            model_foundation = torch.load(
+                args.foundation_model, map_location=args.device
+            )
+            logging.info(
+                f"Using foundation model {args.foundation_model} as initial checkpoint."
+            )
+        args.r_max = model_foundation.r_max.item()
+        if (
+            args.foundation_model not in ["small", "medium", "large"]
+            and args.pt_train_file is None
+        ):
+            logging.warning(
+                "Using multiheads finetuning with a foundation model that is not a Materials Project model, need to provied a path to a pretraining file with --pt_train_file."
+            )
+            args.multiheads_finetuning = False
+        if args.multiheads_finetuning:
+            assert (
+                args.E0s != "average"
+            ), "average atomic energies cannot be used for multiheads finetuning"
+            # check that the foundation model has a single head, if not, use the first head
+            if not args.force_mh_ft_lr:
+                logging.info(
+                    "Multihead finetuning mode, setting learning rate to 0.001 and EMA to True. To use a different learning rate, set --force_mh_ft_lr=True."
+                )
+                args.lr = 0.0001
+                args.ema = True
+                args.ema_decay = 0.99999
+            logging.info(
+                "Using multiheads finetuning mode, setting learning rate to 0.001 and EMA to True"
+            )
+            if hasattr(model_foundation, "heads"):
+                if len(model_foundation.heads) > 1:
+                    logging.warning(
+                        "Mutlihead finetuning with models with more than one head is not supported, using the first head as foundation head."
+                    )
+                    model_foundation = remove_pt_head(
+                        model_foundation, args.foundation_head
+                    )
+    else:
+        args.multiheads_finetuning = False
+
+    if args.heads is not None:
+        args.heads = ast.literal_eval(args.heads)
+    else:
+        args.heads = prepare_default_head(args)
+
+    logging.info("===========LOADING INPUT DATA===========")
+    heads = list(args.heads.keys())
+    logging.info(f"Using heads: {heads}")
+    head_configs: List[HeadConfig] = []
+    for head, head_args in args.heads.items():
+        logging.info(f"=============    Processing head {head}     ===========")
+        head_config = dict_head_to_dataclass(head_args, head, args)
+
+        # Handle train_file and valid_file - normalize to lists
+        if hasattr(head_config, "train_file") and head_config.train_file is not None:
+            head_config.train_file = normalize_file_paths(head_config.train_file)
+        if hasattr(head_config, "valid_file") and head_config.valid_file is not None:
+            head_config.valid_file = normalize_file_paths(head_config.valid_file)
+        if hasattr(head_config, "test_file") and head_config.test_file is not None:
+            head_config.test_file = normalize_file_paths(head_config.test_file)
+
+        if head_config.statistics_file is not None:
+            with open(head_config.statistics_file, "r") as f:  # pylint: disable=W1514
+                statistics = json.load(f)
+            logging.info("Using statistics json file")
+            head_config.r_max = (
+                statistics["r_max"] if args.foundation_model is None else args.r_max
+            )
+            head_config.atomic_numbers = statistics["atomic_numbers"]
+            head_config.mean = statistics["mean"]
+            head_config.std = statistics["std"]
+            head_config.avg_num_neighbors = statistics["avg_num_neighbors"]
+            head_config.compute_avg_num_neighbors = False
+            if isinstance(statistics["atomic_energies"], str) and statistics[
+                "atomic_energies"
+            ].endswith(".json"):
+                with open(statistics["atomic_energies"], "r", encoding="utf-8") as f:
+                    atomic_energies = json.load(f)
+                head_config.E0s = atomic_energies
+                head_config.atomic_energies_dict = ast.literal_eval(atomic_energies)
+            else:
+                head_config.E0s = statistics["atomic_energies"]
+                head_config.atomic_energies_dict = ast.literal_eval(
+                    statistics["atomic_energies"]
+                )
+
+        if any(check_path_ase_read(f) for f in head_config.train_file):
+
+            train_files_ase_list = [
+                f for f in head_config.train_file if check_path_ase_read(f)
+            ]
+            valid_files_ase_list = None
+            test_files_ase_list = None
+            if head_config.valid_file:
+                valid_files_ase_list = [
+                    f for f in head_config.valid_file if check_path_ase_read(f)
+                ]
+            if head_config.test_file:
+                test_files_ase_list = [
+                    f for f in head_config.test_file if check_path_ase_read(f)
+                ]
+            config_type_weights = get_config_type_weights(
+                head_config.config_type_weights
+            )
+            
+            collections, atomic_energies_dict = get_dataset_from_xyz(
+                work_dir=args.work_dir,
+                train_path=train_files_ase_list,
+                valid_path=valid_files_ase_list,
+                valid_fraction=head_config.valid_fraction,
+                config_type_weights=config_type_weights,
+                test_path=test_files_ase_list,
+                seed=args.seed,
+                energy_key=head_config.energy_key,
+                forces_key=head_config.forces_key,
+                stress_key=head_config.stress_key,
+                virials_key=head_config.virials_key,
+                dipole_key=head_config.dipole_key,
+                charges_key=head_config.charges_key,
+                magmom_key=head_config.magmom_key,
+                magforces_key=head_config.magforces_key,
+                head_name=head_config.head_name,
+                keep_isolated_atoms=head_config.keep_isolated_atoms,
+            )
+            
+            head_config.collections = SubsetCollection(
+                train=collections.train,
+                valid=collections.valid,
+                tests=collections.tests,
+            )
+            head_config.atomic_energies_dict = atomic_energies_dict
+            logging.info(
+                f"Total number of configurations: train={len(collections.train)}, valid={len(collections.valid)}, "
+                f"tests=[{', '.join([name + ': ' + str(len(test_configs)) for name, test_configs in collections.tests])}],"
+            )
+        head_configs.append(head_config)
+
+    if all(
+        check_path_ase_read(head_config.train_file[0]) for head_config in head_configs
+    ):
+        size_collections_train = sum(
+            len(head_config.collections.train) for head_config in head_configs
+        )
+        size_collections_valid = sum(
+            len(head_config.collections.valid) for head_config in head_configs
+        )
+        if size_collections_train < args.batch_size:
+            logging.error(
+                f"Batch size ({args.batch_size}) is larger than the number of training data ({size_collections_train})"
+            )
+        if size_collections_valid < args.valid_batch_size:
+            logging.warning(
+                f"Validation batch size ({args.valid_batch_size}) is larger than the number of validation data ({size_collections_valid})"
+            )
+
+    if args.multiheads_finetuning:
+        logging.info(
+            "==================Using multiheads finetuning mode=================="
+        )
+        args.loss = "universal"
+        if (
+            args.foundation_model in ["small", "medium", "large"]
+            or args.pt_train_file == "mp"
+        ):
+            logging.info(
+                "Using foundation model for multiheads finetuning with Materials Project data"
+            )
+            heads = list(dict.fromkeys(["pt_head"] + heads))
+            head_config_pt = HeadConfig(
+                head_name="pt_head",
+                E0s="foundation",
+                statistics_file=args.statistics_file,
+                compute_avg_num_neighbors=False,
+                avg_num_neighbors=model_foundation.interactions[0].avg_num_neighbors,
+            )
+            collections = assemble_mp_data(args, tag, head_configs)
+            head_config_pt.collections = collections
+            head_config_pt.train_file = [f"mp_finetuning-{tag}.xyz"]
+            head_configs.append(head_config_pt)
+        else:
+            logging.info(
+                f"Using foundation model for multiheads finetuning with {args.pt_train_file}"
+            )
+            heads = list(dict.fromkeys(["pt_head"] + heads))
+
+            # Use pt-specific keys if provided, otherwise fall back to general keys
+            pt_energy_key = args.pt_energy_key or args.energy_key
+            pt_forces_key = args.pt_forces_key or args.forces_key
+            pt_stress_key = args.pt_stress_key or args.stress_key
+            pt_virials_key = args.pt_virials_key or args.virials_key
+            pt_dipole_key = args.pt_dipole_key or args.dipole_key
+            pt_charges_key = args.pt_charges_key or args.charges_key
+            pt_magmom_key = args.pt_magmom_key or args.magmom_key
+
+            logging.info(
+                f"Using the following keys for pt_head: energy={pt_energy_key}, forces={pt_forces_key}, "
+                f"stress={pt_stress_key}, virials={pt_virials_key}, dipole={pt_dipole_key}, charges={pt_charges_key}, magmom={pt_magmom_key}"
+            )
+
+            # Normalize file paths
+            pt_train_file = normalize_file_paths(args.pt_train_file)
+            pt_valid_file = (
+                normalize_file_paths(args.pt_valid_file) if args.pt_valid_file else None
+            )
+
+            # Check if pt_train_file is ASE readable (e.g., xyz) vs LMDB/HDF5
+            is_ase_readable = all(check_path_ase_read(f) for f in pt_train_file)
+
+            head_config_pt = HeadConfig(
+                head_name="pt_head",
+                train_file=pt_train_file,
+                valid_file=pt_valid_file,
+                E0s="foundation",
+                statistics_file=args.statistics_file,
+                valid_fraction=args.valid_fraction,
+                config_type_weights=None,
+                energy_key=pt_energy_key,
+                forces_key=pt_forces_key,
+                stress_key=pt_stress_key,
+                virials_key=pt_virials_key,
+                dipole_key=pt_dipole_key,
+                charges_key=pt_charges_key,
+                magmom_key=pt_magmom_key,
+                keep_isolated_atoms=args.keep_isolated_atoms,
+                avg_num_neighbors=model_foundation.interactions[0].avg_num_neighbors,
+                compute_avg_num_neighbors=False,
+            )
+
+            if is_ase_readable:
+                # For xyz files, use get_dataset_from_xyz
+                collections, atomic_energies_dict = get_dataset_from_xyz(
+                    work_dir=args.work_dir,
+                    train_path=args.pt_train_file,
+                    valid_path=args.pt_valid_file,
+                    valid_fraction=args.valid_fraction,
+                    config_type_weights=None,
+                    test_path=None,
+                    seed=args.seed,
+                    energy_key=pt_energy_key,
+                    forces_key=pt_forces_key,
+                    stress_key=pt_stress_key,
+                    virials_key=pt_virials_key,
+                    dipole_key=pt_dipole_key,
+                    charges_key=pt_charges_key,
+                    magmom_key=pt_magmom_key,
+                    head_name="pt_head",
+                    keep_isolated_atoms=args.keep_isolated_atoms,
+                )
+                head_config_pt.collections = collections
+                logging.info(
+                    f"Loaded ASE readable pretraining data: train={len(collections.train)}, valid={len(collections.valid)}"
+                )
+            else:
+                logging.info(
+                    f"Pretraining data file(s) will be loaded as LMDB/HDF5: {pt_train_file}"
+                )
+
+            head_configs.append(head_config_pt)
+
+        all_ase_readable = all(
+            all(check_path_ase_read(f) for f in head_config.train_file)
+            for head_config in head_configs
+        )
+        if all_ase_readable:
+            ratio_pt_ft = size_collections_train / len(head_config_pt.collections.train)
+            if ratio_pt_ft < 0.1:
+                logging.warning(
+                    f"Ratio of the number of configurations in the training set and the in the pt_train_file is {ratio_pt_ft}, "
+                    f"increasing the number of configurations in the fine-tuning heads by {int(0.1 / ratio_pt_ft)}"
+                )
+                for head_config in head_configs:
+                    if head_config.head_name == "pt_head":
+                        continue
+                    head_config.collections.train += (
+                        head_config.collections.train * int(0.1 / ratio_pt_ft)
+                    )
+            logging.info(
+                f"Total number of configurations in pretraining: train={len(head_config_pt.collections.train)}, valid={len(head_config_pt.collections.valid)}"
+            )
+        else:
+            logging.debug(
+                "Using LMDB/HDF5 datasets for pretraining or fine-tuning - skipping ratio check"
+            )
+
+    # Atomic number table
+    # yapf: disable
+    for head_config in head_configs:
+        if head_config.atomic_numbers is None:
+            assert all(check_path_ase_read(f) for f in head_config.train_file), "Must specify atomic_numbers when using .h5 or .aselmdb train_file input"
+            z_table_head = tools.get_atomic_number_table_from_zs(
+                z
+                for configs in (head_config.collections.train, head_config.collections.valid)
+                for config in configs
+                for z in config.atomic_numbers
+            )
+            head_config.atomic_numbers = z_table_head.zs
+            head_config.z_table = z_table_head
+        else:
+            if head_config.statistics_file is None:
+                logging.info("Using atomic numbers from command line argument")
+            else:
+                logging.info("Using atomic numbers from statistics file")
+            zs_list = ast.literal_eval(head_config.atomic_numbers)
+            assert isinstance(zs_list, list)
+            z_table_head = tools.AtomicNumberTable(zs_list)
+            head_config.atomic_numbers = zs_list
+            head_config.z_table = z_table_head
+        # yapf: enable
+    all_atomic_numbers = set()
+    for head_config in head_configs:
+        all_atomic_numbers.update(head_config.atomic_numbers)
+    z_table = AtomicNumberTable(sorted(list(all_atomic_numbers)))
+    if args.foundation_model_elements and model_foundation:
+        z_table = AtomicNumberTable(sorted(model_foundation.atomic_numbers.tolist()))
+    logging.info(f"Atomic Numbers used: {z_table.zs}")
+
+    # Atomic energies
+    atomic_energies_dict = {}
+    for head_config in head_configs:
+        if head_config.atomic_energies_dict is None or len(head_config.atomic_energies_dict) == 0:
+            assert head_config.E0s is not None, "Atomic energies must be provided"
+            if all(check_path_ase_read(f) for f in head_config.train_file) and head_config.E0s.lower() != "foundation":
+                atomic_energies_dict[head_config.head_name] = get_atomic_energies(
+                    head_config.E0s, head_config.collections.train, head_config.z_table
+                )
+            elif head_config.E0s.lower() == "foundation":
+                assert args.foundation_model is not None
+                z_table_foundation = AtomicNumberTable(
+                    [int(z) for z in model_foundation.atomic_numbers]
+                )
+                foundation_atomic_energies = model_foundation.atomic_energies_fn.atomic_energies
+                if foundation_atomic_energies.ndim > 1:
+                    foundation_atomic_energies = foundation_atomic_energies.squeeze()
+                    if foundation_atomic_energies.ndim == 2:
+                        foundation_atomic_energies = foundation_atomic_energies[0]
+                        logging.info("Foundation model has multiple heads, using the first head as foundation E0s.")
+                atomic_energies_dict[head_config.head_name] = {
+                    z: foundation_atomic_energies[
+                        z_table_foundation.z_to_index(z)
+                    ].item()
+                    for z in z_table.zs
+                }
+            else:
+                atomic_energies_dict[head_config.head_name] = get_atomic_energies(head_config.E0s, None, head_config.z_table)
+        else:
+            atomic_energies_dict[head_config.head_name] = head_config.atomic_energies_dict
+
+    # Atomic energies for multiheads finetuning
+    if args.multiheads_finetuning:
+        assert (
+            model_foundation is not None
+        ), "Model foundation must be provided for multiheads finetuning"
+        z_table_foundation = AtomicNumberTable(
+            [int(z) for z in model_foundation.atomic_numbers]
+        )
+        foundation_atomic_energies = model_foundation.atomic_energies_fn.atomic_energies
+        if foundation_atomic_energies.ndim > 1:
+            foundation_atomic_energies = foundation_atomic_energies.squeeze()
+            if foundation_atomic_energies.ndim == 2:
+                foundation_atomic_energies = foundation_atomic_energies[0]
+                logging.info("Foundation model has multiple heads, using the first head as foundation E0s.")
+        atomic_energies_dict["pt_head"] = {
+            z: foundation_atomic_energies[
+                z_table_foundation.z_to_index(z)
+            ].item()
+            for z in z_table.zs
+        }
+
+    # Padding atomic energies if keeping all elements of the foundation model
+    if args.foundation_model_elements and model_foundation:
+        atomic_energies_dict_padded = {}
+        for head_name, head_energies in atomic_energies_dict.items():
+            energy_head_padded = {}
+            for z in z_table.zs:
+                energy_head_padded[z] = head_energies.get(z, 0.0)
+            atomic_energies_dict_padded[head_name] = energy_head_padded
+        atomic_energies_dict = atomic_energies_dict_padded
+
+    if args.model == "AtomicDipolesMACE":
+        atomic_energies = None
+        dipole_only = True
+        args.compute_dipole = True
+        args.compute_energy = False
+        args.compute_forces = False
+        args.compute_virials = False
+        args.compute_stress = False
+    else:
+        dipole_only = False
+        if args.model == "EnergyDipolesMACE":
+            args.compute_dipole = True
+            args.compute_energy = True
+            args.compute_forces = True
+            args.compute_virials = False
+            args.compute_stress = False
+        else:
+            args.compute_energy = True
+            args.compute_dipole = False
+        # atomic_energies: np.ndarray = np.array(
+        #     [atomic_energies_dict[z] for z in z_table.zs]
+        # )
+        atomic_energies = dict_to_array(atomic_energies_dict, heads)
+        for head_config in head_configs:
+            try:
+                logging.info(f"Atomic Energies used (z: eV) for head {head_config.head_name}: " + "{" + ", ".join([f"{z}: {atomic_energies_dict[head_config.head_name][z]}" for z in head_config.z_table.zs]) + "}")
+            except KeyError as e:
+                raise KeyError(f"Atomic number {e} not found in atomic_energies_dict for head {head_config.head_name}, add E0s for this atomic number") from e
+
+    # Load datasets for each head, supporting multiple files per head
+    valid_sets = {head: [] for head in heads}
+    train_sets = {head: [] for head in heads}
+
+    for head_config in head_configs:
+        train_datasets = []
+
+        logging.info(f"Processing datasets for head '{head_config.head_name}'")
+        ase_files = [f for f in head_config.train_file if check_path_ase_read(f)]
+        non_ase_files = [f for f in head_config.train_file if not check_path_ase_read(f)]
+
+        if ase_files:
+            dataset = load_dataset_for_path(
+            file_path=ase_files,
+            r_max=args.r_max,
+            z_table=z_table,
+            head_config=head_config,
+            heads=heads,
+            collection=head_config.collections.train,
+            )
+            train_datasets.append(dataset)
+            logging.debug(f"Successfully loaded dataset from ASE files: {ase_files}")
+
+        for file in non_ase_files:
+            dataset = load_dataset_for_path(
+            file_path=file,
+            r_max=args.r_max,
+            z_table=z_table,
+            head_config=head_config,
+            heads=heads,
+            )
+            train_datasets.append(dataset)
+            logging.debug(f"Successfully loaded dataset from non-ASE file: {file}")
+
+        if not train_datasets:
+            raise ValueError(f"No valid training datasets found for head {head_config.head_name}")
+
+        train_sets[head_config.head_name] = combine_datasets(train_datasets, head_config.head_name)
+
+        if head_config.valid_file:
+            valid_datasets = []
+
+            valid_ase_files = [f for f in head_config.valid_file if check_path_ase_read(f)]
+            valid_non_ase_files = [f for f in head_config.valid_file if not check_path_ase_read(f)]
+
+            if valid_ase_files:
+                valid_dataset = load_dataset_for_path(
+                    file_path=valid_ase_files,
+                    r_max=args.r_max,
+                    z_table=z_table,
+                    head_config=head_config,
+                    heads=heads,
+                    collection=head_config.collections.valid,
+                )
+                valid_datasets.append(valid_dataset)
+                logging.debug(f"Successfully loaded validation dataset from ASE files: {valid_ase_files}")
+            for valid_file in valid_non_ase_files:
+                valid_dataset = load_dataset_for_path(
+                file_path=valid_file,
+                r_max=args.r_max,
+                z_table=z_table,
+                head_config=head_config,
+                heads=heads,
+            )
+                valid_datasets.append(valid_dataset)
+                logging.debug(f"Successfully loaded validation dataset from {valid_file}")
+
+            # Combine validation datasets
+            if valid_datasets:
+                valid_sets[head_config.head_name] = combine_datasets(valid_datasets, f"{head_config.head_name}_valid")
+                logging.info(f"Combined validation datasets for {head_config.head_name}")
+
+        # If no valid file is provided but collection exist, use the validation set from the collection
+        if head_config.valid_file is None and head_config.collections.valid:
+            valid_sets[head_config.head_name] = [
+                data.AtomicData.from_config(
+                    config, z_table=z_table, cutoff=args.r_max, heads=heads
+                )
+                for config in head_config.collections.valid
+            ]
+        if not valid_sets[head_config.head_name]:
+            raise ValueError(f"No valid datasets found for head {head_config.head_name}, please provide a valid_file or a valid_fraction")
+
+        # Create data loader for this head
+        if isinstance(train_sets[head_config.head_name], list):
+            dataset_size = len(train_sets[head_config.head_name])
+        else:
+            dataset_size = len(train_sets[head_config.head_name])
+        logging.info(f"Head '{head_config.head_name}' training dataset size: {dataset_size}")
+
+        train_loader_head = torch_geometric.dataloader.DataLoader(
+            dataset=train_sets[head_config.head_name],
+            batch_size=args.batch_size,
+            shuffle=True,
+            drop_last=(not args.lbfgs),
+            pin_memory=args.pin_memory,
+            num_workers=args.num_workers,
+            generator=torch.Generator().manual_seed(args.seed),
+        )
+        head_config.train_loader = train_loader_head
+
+    # concatenate all the trainsets
+    train_set = ConcatDataset([train_sets[head] for head in heads])
+    train_sampler, valid_sampler = None, None
+    if args.distributed:
+        train_sampler = torch.utils.data.distributed.DistributedSampler(
+            train_set,
+            num_replicas=world_size,
+            rank=rank,
+            shuffle=True,
+            drop_last=(not args.lbfgs),
+            seed=args.seed,
+        )
+        valid_samplers = {}
+        for head, valid_set in valid_sets.items():
+            valid_sampler = torch.utils.data.distributed.DistributedSampler(
+                valid_set,
+                num_replicas=world_size,
+                rank=rank,
+                shuffle=True,
+                drop_last=True,
+                seed=args.seed,
+            )
+            valid_samplers[head] = valid_sampler
+    train_loader = torch_geometric.dataloader.DataLoader(
+        dataset=train_set,
+        batch_size=args.batch_size,
+        sampler=train_sampler,
+        shuffle=(train_sampler is None),
+        drop_last=(train_sampler is None and not args.lbfgs),
+        pin_memory=args.pin_memory,
+        num_workers=args.num_workers,
+        generator=torch.Generator().manual_seed(args.seed),
+    )
+    if args.loss == "EvenSpline1BodyLoss":
+        train_loader = torch_geometric.dataloader.DataLoader(
+            dataset=train_set,
+            batch_size=len(train_set),
+            sampler=train_sampler,
+            shuffle=False,
+            drop_last=(train_sampler is None and not args.lbfgs),
+            pin_memory=args.pin_memory,
+            num_workers=args.num_workers,
+            generator=torch.Generator().manual_seed(args.seed),
+        )
+    valid_loaders = {heads[i]: None for i in range(len(heads))}
+    if not isinstance(valid_sets, dict):
+        valid_sets = {"Default": valid_sets}
+    for head, valid_set in valid_sets.items():
+        valid_loaders[head] = torch_geometric.dataloader.DataLoader(
+            dataset=valid_set,
+            batch_size=args.valid_batch_size,
+            sampler=valid_samplers[head] if args.distributed else None,
+            shuffle=False,
+            drop_last=False,
+            pin_memory=args.pin_memory,
+            num_workers=args.num_workers,
+            generator=torch.Generator().manual_seed(args.seed),
+        )
+        if args.loss == "EvenSpline1BodyLoss":
+            valid_loaders[head] = torch_geometric.dataloader.DataLoader(
+                dataset=valid_set,
+                batch_size=len(valid_set),
+                sampler=valid_samplers[head] if args.distributed else None,
+                shuffle=False,
+                drop_last=False,
+                pin_memory=args.pin_memory,
+                num_workers=args.num_workers,
+                generator=torch.Generator().manual_seed(args.seed),
+            )
+
+    loss_fn = get_loss_fn(args, dipole_only, args.compute_dipole)
+    args.avg_num_neighbors = get_avg_num_neighbors(head_configs, args, train_loader, device)
+
+    # Model
+    model, output_args = configure_model(args, train_loader, atomic_energies, model_foundation, heads, z_table, head_configs)
+    model.to(device)
+    print("output_args: ", output_args)
+    logging.debug(model)
+    logging.info(f"Total number of parameters: {tools.count_parameters(model)}")
+    logging.info("")
+    logging.info("===========OPTIMIZER INFORMATION===========")
+    logging.info(f"Using {args.optimizer.upper()} as parameter optimizer")
+    logging.info(f"Batch size: {args.batch_size}")
+    if args.ema:
+        logging.info(f"Using Exponential Moving Average with decay: {args.ema_decay}")
+    logging.info(
+        f"Number of gradient updates: {int(args.max_num_epochs*len(train_set)/args.batch_size)}"
+    )
+    logging.info(f"Learning rate: {args.lr}, weight decay: {args.weight_decay}")
+    logging.info(loss_fn)
+
+    # Cueq
+    if args.enable_cueq:
+        logging.info("Converting model to CUEQ for accelerated training")
+        #assert model.__class__.__name__ in ["MACE", "ScaleShiftMACE"]
+        model = run_e3nn_to_cueq(deepcopy(model), device=device)
+    # Optimizer
+    param_options = get_params_options(args, model)
+    optimizer: torch.optim.Optimizer
+    optimizer = get_optimizer(args, param_options)
+    if args.device == "xpu":
+        logging.info("Optimzing model and optimzier for XPU")
+        model, optimizer = ipex.optimize(model, optimizer=optimizer)
+    logger = tools.MetricsLogger(
+        directory=args.results_dir, tag=tag + "_train"
+    )  # pylint: disable=E1123
+
+    lr_scheduler = LRScheduler(optimizer, args)
+
+    swa: Optional[tools.SWAContainer] = None
+    swas = [False]
+    if args.swa:
+        swa, swas = get_swa(args, model, optimizer, swas, dipole_only)
+
+    checkpoint_handler = tools.CheckpointHandler(
+        directory=args.checkpoints_dir,
+        tag=tag,
+        keep=args.keep_checkpoints,
+        swa_start=args.start_swa,
+    )
+
+    start_epoch = 0
+    restart_lbfgs = False
+    opt_start_epoch = None
+    if args.restart_latest:
+        try:
+            opt_start_epoch = checkpoint_handler.load_latest(
+                state=tools.CheckpointState(model, optimizer, lr_scheduler),
+                swa=True,
+                device=device,
+            )
+        except Exception:  # pylint: disable=W0703
+            try:
+                opt_start_epoch = checkpoint_handler.load_latest(
+                    state=tools.CheckpointState(model, optimizer, lr_scheduler),
+                    swa=False,
+                    device=device,
+                )
+            except Exception: # pylint: disable=W0703
+                restart_lbfgs = True
+        if opt_start_epoch is not None:
+            start_epoch = opt_start_epoch
+
+    ema: Optional[ExponentialMovingAverage] = None
+    if args.ema:
+        ema = ExponentialMovingAverage(model.parameters(), decay=args.ema_decay)
+    else:
+        for group in optimizer.param_groups:
+            group["lr"] = args.lr
+
+    if args.lbfgs:
+        logging.info("Switching optimizer to LBFGS")
+        optimizer = LBFGS(model.parameters(),
+                          history_size=200,
+                          max_iter=20,
+                          line_search_fn="strong_wolfe")
+        if restart_lbfgs:
+            opt_start_epoch = checkpoint_handler.load_latest(
+                state=tools.CheckpointState(model, optimizer, lr_scheduler),
+                swa=False,
+                device=device,
+            )
+            if opt_start_epoch is not None:
+                start_epoch = opt_start_epoch
+
+    if args.wandb:
+        setup_wandb(args)
+    if args.distributed:
+        distributed_model = DDP(model, device_ids=[local_rank], find_unused_parameters=True,)
+    else:
+        distributed_model = None
+
+
+    train_valid_data_loader = {}
+    for head_config in head_configs:
+        data_loader_name = "train_" + head_config.head_name
+        train_valid_data_loader[data_loader_name] = head_config.train_loader
+    for head, valid_loader in valid_loaders.items():
+        data_load_name = "valid_" + head
+        train_valid_data_loader[data_load_name] = valid_loader
+
+    if args.plot and args.plot_frequency > 0:
+        try:
+            plotter = TrainingPlotter(
+                results_dir=logger.path,
+                heads=heads,
+                table_type=args.error_table,
+                train_valid_data=train_valid_data_loader,
+                test_data={},
+                output_args=output_args,
+                device=device,
+                plot_frequency=args.plot_frequency,
+                distributed=args.distributed,
+                swa_start=swa.start if swa else None
+                )
+        except Exception as e:  # pylint: disable=W0718
+            logging.debug(f"Creating Plotter failed: {e}")
+    else:
+        plotter = None
+
+    if args.dry_run:
+        logging.info("DRY RUN mode enabled. Stopping now.")
+        return
+
+
+    data = collect_magmom_energy(train_loader)
+    for idx, d in data.items():
+        y_init = init_even_spline_interp(np.linalg.norm(d['m'], axis=-1),
+                                    d['E'], 
+                                    model.E_m_spline.u_knots[idx], dtype=torch.float64)
+
+        model.E_m_spline.y[idx].data = y_init
+
+    import torch.optim as optim
+    step_counter = {"n": 0}  # mutable counter
+    optimizer = LBFGS(list(model.E_m_spline.y),
+                      lr = 1.0,
+                      max_iter=300,)
+
+    def curvature_penalty(y):
+        d2 = y[:-2] - 2 * y[1:-1] + y[2:]
+        return torch.mean(d2**2)
+
+    step_counter = {"n": 0}
+
+    def closure():
+        optimizer.zero_grad()
+
+        batch = next(iter(train_loader)).to(device)
+
+        pred = model(
+            batch,
+            training=True,
+            compute_force=False,
+            compute_virials=False,
+            compute_stress=False,
+        )
+
+        # -----------------------------
+        # Data loss (energy only)
+        # -----------------------------
+        # batch["energy"]: reference per-structure energy
+        # pred["energy"]: predicted per-structure energy
+        data_loss = torch.mean((pred["energy"] - batch["energy"])**2)
+
+        # -----------------------------
+        # Smoothness loss (spline-space)
+        # -----------------------------
+        smooth_losses = []
+        for elem_idx in range(len(model.E_m_spline.y)):
+            y = model.E_m_spline.y[elem_idx]
+            if y.numel() >= 3:
+                smooth_losses.append(curvature_penalty(y))
+
+        if smooth_losses:
+            smooth_loss = torch.stack(smooth_losses) # .mean()
+        else:
+            smooth_loss = data_loss.new_tensor(0.0)
+
+        lambda_smooth = torch.tensor(args.lambda_smooth,
+                                     device=smooth_loss.device
+                                     )
+        loss = data_loss + (lambda_smooth * smooth_loss).mean()
+        loss.backward()
+
+        # -----------------------------
+        # Logging (safe for LBFGS)
+        # -----------------------------
+        if step_counter["n"] % 5 == 0:
+            with torch.no_grad():
+                print(
+                    f"[LBFGS eval {step_counter['n']:03d}] "
+                    f"loss={loss.item():.4e} | "
+                    f"data={data_loss.item():.4e} | "
+                    f"smooth={smooth_loss.mean().item():.4e}"
+                )
+
+        step_counter["n"] += 1
+        return loss
+
+    optimizer.step(closure)
+    E0_list, E1_list, E2_list = [], [], []
+    
+    # prefactor that the model starts to change value
+    args.prefactor = np.array(args.prefactor)
+
+    # 
+    for s in range(len(model.E_m_spline.y)):
+        u_knots = model.E_m_spline.u_knots[s]   # (K,)
+        y_knots = model.E_m_spline.y[s]         # (K,)
+
+        # physical cutoff (NOT inferred from knots)
+        m0 = model.m_max[s].detach() / args.prefactor[s]
+        # m0 = model.m_max[s].detach() * args.prefactor[s]
+
+        # enable autodiff on m
+        m = m0.clone().requires_grad_(True)
+
+        # spline evaluation at u = m^2
+        u = m * m
+        coeffs = natural_cubic_spline_coeffs(u_knots, y_knots)
+        E = cubic_spline_eval(u, u_knots, coeffs)
+
+        # first derivative dE/dm
+        (dE_dm,) = torch.autograd.grad(
+            E, m, create_graph=True
+        )
+
+        # second derivative d²E/dm²
+        (d2E_dm2,) = torch.autograd.grad(
+            dE_dm, m, retain_graph=False
+        )
+
+        E0_list.append(E.detach())
+        E1_list.append(dE_dm.detach())
+        E2_list.append(d2E_dm2.detach())
+    
+    import pdb; pdb.set_trace()
+    # stack into tensors
+    E0 = torch.stack(E0_list)   # (n_species,)
+    E1  = torch.stack(E1_list)   # (n_species,)
+    E2  = torch.stack(E2_list)   # (n_species,)
+
+    model.saturation = EvenMagSaturationBarrier(
+        m_max=torch.as_tensor(np.array(args.m_max)/np.array(args.prefactor), device=device, dtype=E0.dtype),
+        E2=E2.to(device),
+        E1=E1.to(device),
+        prefactor=args.prefactor
+    ).to(device)
+    
+    checkpoint_handler.save(state=CheckpointState(model, optimizer, lr_scheduler), epochs=0, keep_last=True,)
+    model_path = Path(args.checkpoints_dir) / (tag + ".model")
+    torch.save(model, model_path)
+    
+
+if __name__ == "__main__":
+    main()

--- a/mace/cli/visualise_train.py
+++ b/mace/cli/visualise_train.py
@@ -174,7 +174,7 @@ class TrainingPlotter:
                 stage = "stage_one"
             axsTop[0].legend(loc="best")
             # Save the figure using the appropriate stage in the filename
-            filename = f"{self.results_dir[:-4]}_{head}_{stage}.png"
+            filename = f"{self.results_dir[:-4]}_{head}_{stage}_{model_epoch}.png"
 
             fig.savefig(filename, dpi=300, bbox_inches="tight")
             plt.close(fig)

--- a/mace/data/__init__.py
+++ b/mace/data/__init__.py
@@ -1,4 +1,4 @@
-from .atomic_data import AtomicData
+from .atomic_data import AtomicData, create_random_rotation_loader
 from .hdf5_dataset import HDF5Dataset, dataset_from_sharded_hdf5
 from .lmdb_dataset import LMDBDataset
 from .neighborhood import get_neighborhood
@@ -18,6 +18,7 @@ from .utils import (
 
 __all__ = [
     "get_neighborhood",
+    "create_random_rotation_loader",
     "Configuration",
     "Configurations",
     "random_train_valid_split",

--- a/mace/data/__init__.py
+++ b/mace/data/__init__.py
@@ -1,4 +1,4 @@
-from .atomic_data import AtomicData, create_random_rotation_loader
+from .atomic_data import AtomicData, create_random_rotation_loader, create_random_rotation_dataset
 from .hdf5_dataset import HDF5Dataset, dataset_from_sharded_hdf5
 from .lmdb_dataset import LMDBDataset
 from .neighborhood import get_neighborhood
@@ -19,6 +19,7 @@ from .utils import (
 __all__ = [
     "get_neighborhood",
     "create_random_rotation_loader",
+    "create_random_rotation_dataset",
     "Configuration",
     "Configurations",
     "random_train_valid_split",

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -89,8 +89,6 @@ class AtomicData(torch_geometric.data.Data):
         assert virials is None or virials.shape == (1, 3, 3)
         assert dipole is None or dipole.shape[-1] == 3
         assert charges is None or charges.shape == (num_nodes,)
-        print(forces.shape)
-        print(magmom.shape)
         assert magmom is None or magmom.shape == (num_nodes, 3)
 
         # Aggregate data

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -285,3 +285,85 @@ def get_data_loader(
         shuffle=shuffle,
         drop_last=drop_last,
     )
+
+
+# === for data augmentation ===
+from torch_geometric.transforms import BaseTransform
+import numpy as np
+
+class Random3DRotation(BaseTransform):
+    """
+    Apply a random SO(3) rotation to all magnetic moments in a configuration.
+    A single rotation is applied per structure, preserving relative orientation.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, data):
+        if hasattr(data, 'magmom') and data.magmom is not None:
+            device = data.magmom.device
+            dtype = data.magmom.dtype
+
+            # === Step 1: Sample a random unit quaternion (uniform over SO(3))
+            u1, u2, u3 = torch.rand(3, device=device, dtype=dtype)
+            q1 = torch.sqrt(1 - u1) * torch.sin(2 * np.pi * u2)
+            q2 = torch.sqrt(1 - u1) * torch.cos(2 * np.pi * u2)
+            q3 = torch.sqrt(u1) * torch.sin(2 * np.pi * u3)
+            q4 = torch.sqrt(u1) * torch.cos(2 * np.pi * u3)
+
+            # === Step 2: Convert quaternion to rotation matrix
+            R = torch.tensor([
+                [1 - 2*(q3**2 + q4**2),     2*(q2*q3 - q1*q4),     2*(q2*q4 + q1*q3)],
+                [2*(q2*q3 + q1*q4),     1 - 2*(q2**2 + q4**2),     2*(q3*q4 - q1*q2)],
+                [2*(q2*q4 - q1*q3),         2*(q3*q4 + q1*q2), 1 - 2*(q2**2 + q3**2)]
+            ], device=device, dtype=dtype)
+
+            # === Step 3: Apply to magmom (shape [N, 3])
+            data.magmom = torch.matmul(data.magmom, R.T)
+
+        return data
+
+def create_random_rotation_loader(original_loader):
+    """
+    Create a new DataLoader with hemisphere rotation augmentation.
+    
+    Args:
+        original_loader: Original PyTorch Geometric DataLoader
+    
+    Returns:
+        New DataLoader with hemisphere rotation transform
+    """
+    transform = Random3DRotation()
+    
+    # Apply transform to dataset
+    dataset = original_loader.dataset
+    
+    # Create new dataset with transform
+    class TransformedDataset:
+        def __init__(self, original_dataset, transform):
+            self.dataset = original_dataset
+            self.transform = transform
+        
+        def __len__(self):
+            return len(self.dataset)
+        
+        def __getitem__(self, idx):
+            data = self.dataset[idx]
+            return self.transform(data)
+    
+    transformed_dataset = TransformedDataset(dataset, transform)
+    
+    is_shuffle = False if original_loader.sampler.__class__ == torch.utils.data.sampler.SequentialSampler else True
+
+    # Create new DataLoader with same parameters
+    new_loader = torch_geometric.dataloader.DataLoader(
+        transformed_dataset,
+        batch_size=original_loader.batch_size,
+        shuffle=is_shuffle,
+        num_workers=original_loader.num_workers,
+        pin_memory=original_loader.pin_memory,
+        drop_last=original_loader.drop_last
+    )
+    
+    return new_loader

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -35,6 +35,8 @@ class AtomicData(torch_geometric.data.Data):
     energy: torch.Tensor
     stress: torch.Tensor
     virials: torch.Tensor
+    magmom: torch.Tensor 
+    magforces: torch.Tensor 
     dipole: torch.Tensor
     charges: torch.Tensor
     weight: torch.Tensor
@@ -43,6 +45,7 @@ class AtomicData(torch_geometric.data.Data):
     stress_weight: torch.Tensor
     virials_weight: torch.Tensor
     magmom_weight: torch.Tensor
+    magforces_weight: torch.Tensor
 
     def __init__(
         self,
@@ -59,13 +62,16 @@ class AtomicData(torch_geometric.data.Data):
         stress_weight: Optional[torch.Tensor],  # [,]
         virials_weight: Optional[torch.Tensor],  # [,]
         magmom_weight: Optional[torch.Tensor],  # [,]
+        magforces_weight: Optional[torch.Tensor],  # [,]
         forces: Optional[torch.Tensor],  # [n_nodes, 3]
         energy: Optional[torch.Tensor],  # [, ]
         stress: Optional[torch.Tensor],  # [1,3,3]
         virials: Optional[torch.Tensor],  # [1,3,3]
         dipole: Optional[torch.Tensor],  # [, 3]
         charges: Optional[torch.Tensor],  # [n_nodes, ]
-        magmom: Optional[torch.Tensor] # [n_nodes, 3]
+        magmom: Optional[torch.Tensor], # [n_nodes, 3]
+        magforces: Optional[torch.Tensor]
+
     ):
         # Check shapes
         num_nodes = node_attrs.shape[0]
@@ -81,7 +87,8 @@ class AtomicData(torch_geometric.data.Data):
         assert forces_weight is None or len(forces_weight.shape) == 0
         assert stress_weight is None or len(stress_weight.shape) == 0
         assert virials_weight is None or len(virials_weight.shape) == 0
-        assert magmom_weight is None or len(forces_weight.shape) == 0
+        assert magmom_weight is None or len(magmom_weight.shape) == 0
+        assert magforces_weight is None or len(magforces_weight.shape) == 0
         assert cell is None or cell.shape == (3, 3)
         assert forces is None or forces.shape == (num_nodes, 3)
         assert energy is None or len(energy.shape) == 0
@@ -90,6 +97,7 @@ class AtomicData(torch_geometric.data.Data):
         assert dipole is None or dipole.shape[-1] == 3
         assert charges is None or charges.shape == (num_nodes,)
         assert magmom is None or magmom.shape == (num_nodes, 3)
+        assert magforces is None or magforces.shape == (num_nodes, 3)
 
         # Aggregate data
         data = {
@@ -107,6 +115,7 @@ class AtomicData(torch_geometric.data.Data):
             "stress_weight": stress_weight,
             "virials_weight": virials_weight,
             "magmom_weight": magmom_weight,
+            "magforces_weight": magforces_weight,
             "forces": forces,
             "energy": energy,
             "stress": stress,
@@ -114,6 +123,7 @@ class AtomicData(torch_geometric.data.Data):
             "dipole": dipole,
             "charges": charges,
             "magmom": magmom,
+            "magforces": magforces,
         }
         super().__init__(**data)
 
@@ -184,6 +194,12 @@ class AtomicData(torch_geometric.data.Data):
             else 1
         )
 
+        magforces_weight = (
+            torch.tensor(config.magforces_weight, dtype=torch.get_default_dtype())
+            if config.magforces_weight is not None
+            else 1
+        )
+
 
         forces = (
             torch.tensor(config.forces, dtype=torch.get_default_dtype())
@@ -225,6 +241,12 @@ class AtomicData(torch_geometric.data.Data):
             if config.magmom is not None
             else None
         )
+        magforces = (
+            torch.tensor(config.magforces, dtype=torch.get_default_dtype())
+            if config.magforces is not None
+            else None
+        )
+
         return cls(
             edge_index=torch.tensor(edge_index, dtype=torch.long),
             positions=torch.tensor(config.positions, dtype=torch.get_default_dtype()),
@@ -239,6 +261,7 @@ class AtomicData(torch_geometric.data.Data):
             stress_weight=stress_weight,
             virials_weight=virials_weight,
             magmom_weight=magmom_weight,
+            magforces_weight=magforces_weight,
             forces=forces,
             energy=energy,
             stress=stress,
@@ -246,6 +269,7 @@ class AtomicData(torch_geometric.data.Data):
             dipole=dipole,
             charges=charges,
             magmom=magmom,
+            magforces=magforces,
         )
 
 

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -42,6 +42,7 @@ class AtomicData(torch_geometric.data.Data):
     forces_weight: torch.Tensor
     stress_weight: torch.Tensor
     virials_weight: torch.Tensor
+    magmom_weight: torch.Tensor
 
     def __init__(
         self,
@@ -57,12 +58,14 @@ class AtomicData(torch_geometric.data.Data):
         forces_weight: Optional[torch.Tensor],  # [,]
         stress_weight: Optional[torch.Tensor],  # [,]
         virials_weight: Optional[torch.Tensor],  # [,]
+        magmom_weight: Optional[torch.Tensor],  # [,]
         forces: Optional[torch.Tensor],  # [n_nodes, 3]
         energy: Optional[torch.Tensor],  # [, ]
         stress: Optional[torch.Tensor],  # [1,3,3]
         virials: Optional[torch.Tensor],  # [1,3,3]
         dipole: Optional[torch.Tensor],  # [, 3]
         charges: Optional[torch.Tensor],  # [n_nodes, ]
+        magmom: Optional[torch.Tensor] # [n_nodes, 3]
     ):
         # Check shapes
         num_nodes = node_attrs.shape[0]
@@ -78,6 +81,7 @@ class AtomicData(torch_geometric.data.Data):
         assert forces_weight is None or len(forces_weight.shape) == 0
         assert stress_weight is None or len(stress_weight.shape) == 0
         assert virials_weight is None or len(virials_weight.shape) == 0
+        assert magmom_weight is None or len(forces_weight.shape) == 0
         assert cell is None or cell.shape == (3, 3)
         assert forces is None or forces.shape == (num_nodes, 3)
         assert energy is None or len(energy.shape) == 0
@@ -85,6 +89,10 @@ class AtomicData(torch_geometric.data.Data):
         assert virials is None or virials.shape == (1, 3, 3)
         assert dipole is None or dipole.shape[-1] == 3
         assert charges is None or charges.shape == (num_nodes,)
+        print(forces.shape)
+        print(magmom.shape)
+        assert magmom is None or magmom.shape == (num_nodes, 3)
+
         # Aggregate data
         data = {
             "num_nodes": num_nodes,
@@ -100,12 +108,14 @@ class AtomicData(torch_geometric.data.Data):
             "forces_weight": forces_weight,
             "stress_weight": stress_weight,
             "virials_weight": virials_weight,
+            "magmom_weight": magmom_weight,
             "forces": forces,
             "energy": energy,
             "stress": stress,
             "virials": virials,
             "dipole": dipole,
             "charges": charges,
+            "magmom": magmom,
         }
         super().__init__(**data)
 
@@ -170,6 +180,13 @@ class AtomicData(torch_geometric.data.Data):
             else 1
         )
 
+        magmom_weight = (
+            torch.tensor(config.magmom_weight, dtype=torch.get_default_dtype())
+            if config.magmom_weight is not None
+            else 1
+        )
+
+
         forces = (
             torch.tensor(config.forces, dtype=torch.get_default_dtype())
             if config.forces is not None
@@ -194,6 +211,7 @@ class AtomicData(torch_geometric.data.Data):
             if config.virials is not None
             else None
         )
+        
         dipole = (
             torch.tensor(config.dipole, dtype=torch.get_default_dtype()).unsqueeze(0)
             if config.dipole is not None
@@ -204,7 +222,11 @@ class AtomicData(torch_geometric.data.Data):
             if config.charges is not None
             else None
         )
-
+        magmom = (
+            torch.tensor(config.magmom, dtype=torch.get_default_dtype())
+            if config.magmom is not None
+            else None
+        )
         return cls(
             edge_index=torch.tensor(edge_index, dtype=torch.long),
             positions=torch.tensor(config.positions, dtype=torch.get_default_dtype()),
@@ -218,12 +240,14 @@ class AtomicData(torch_geometric.data.Data):
             forces_weight=forces_weight,
             stress_weight=stress_weight,
             virials_weight=virials_weight,
+            magmom_weight=magmom_weight,
             forces=forces,
             energy=energy,
             stress=stress,
             virials=virials,
             dipole=dipole,
             charges=charges,
+            magmom=magmom,
         )
 
 

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -319,8 +319,10 @@ class Random3DRotation(BaseTransform):
             ], device=device, dtype=dtype)
 
             # === Step 3: Apply to magmom (shape [N, 3])
+            # import pdb; pdb.set_trace();
             data.magmom = torch.matmul(data.magmom, R.T)
-
+            if data.magforces is not None:
+                data.magforces = torch.matmul(data.magforces, R.T)
         return data
 
 def create_random_rotation_dataset(dataset):

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -200,7 +200,6 @@ class AtomicData(torch_geometric.data.Data):
             else 1
         )
 
-
         forces = (
             torch.tensor(config.forces, dtype=torch.get_default_dtype())
             if config.forces is not None
@@ -323,6 +322,36 @@ class Random3DRotation(BaseTransform):
             data.magmom = torch.matmul(data.magmom, R.T)
 
         return data
+
+def create_random_rotation_dataset(dataset):
+    """
+    Create a new DataLoader with hemisphere rotation augmentation.
+    
+    Args:
+        original_loader: Original PyTorch Geometric DataLoader
+    
+    Returns:
+        New DataLoader with hemisphere rotation transform
+    """
+    # Apply transform to dataset
+    transform = Random3DRotation()
+    
+    # Create new dataset with transform
+    class TransformedDataset:
+        def __init__(self, original_dataset, transform):
+            self.dataset = original_dataset
+            self.transform = transform
+        
+        def __len__(self):
+            return len(self.dataset)
+        
+        def __getitem__(self, idx):
+            data = self.dataset[idx]
+            return self.transform(data)
+    
+    transformed_dataset = TransformedDataset(dataset, transform)
+    
+    return transformed_dataset
 
 def create_random_rotation_loader(original_loader):
     """

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -22,6 +22,7 @@ Stress = np.ndarray  # [6, ], [3,3], [9, ]
 Virials = np.ndarray  # [6, ], [3,3], [9, ]
 Charges = np.ndarray  # [..., 1]
 Magmom = np.ndarray  # [..., 3]
+Magforces = np.ndarray # [..., 3]
 Cell = np.ndarray  # [3,3]
 Pbc = tuple  # (3,)
 
@@ -40,6 +41,7 @@ class Configuration:
     dipole: Optional[Vector] = None  # Debye
     charges: Optional[Charges] = None  # atomic unit
     magmom: Optional[Magmom] = None
+    magforces: Optional[Magforces] = None
     cell: Optional[Cell] = None
     pbc: Optional[Pbc] = None
 
@@ -49,6 +51,7 @@ class Configuration:
     stress_weight: float = 1.0  # weight of config stress in loss
     virials_weight: float = 1.0  # weight of config virial in loss
     magmom_weight: float = 1.0  # weight of config virial in loss
+    magforces_weight: float = 1.0  # weight of config virial in loss
     config_type: Optional[str] = DEFAULT_CONFIG_TYPE  # config_type of config
     head: Optional[str] = "Default"  # head used to compute the config
 
@@ -95,6 +98,7 @@ def config_from_atoms_list(
     virials_key="REF_virials",
     dipole_key="REF_dipole",
     charges_key="REF_charges",
+    magforces_key="REF_magforces",
     head_key="head",
     config_type_weights: Optional[Dict[str, float]] = None,
 ) -> Configurations:
@@ -113,6 +117,7 @@ def config_from_atoms_list(
                 virials_key=virials_key,
                 dipole_key=dipole_key,
                 charges_key=charges_key,
+                magforces_key=magforces_key,
                 head_key=head_key,
                 config_type_weights=config_type_weights,
             )
@@ -128,6 +133,7 @@ def config_from_atoms(
     virials_key="REF_virials",
     dipole_key="REF_dipole",
     charges_key="REF_charges",
+    magforces_key="REF_magforces",
     head_key="head",
     config_type_weights: Optional[Dict[str, float]] = None,
 ) -> Configuration:
@@ -141,6 +147,8 @@ def config_from_atoms(
     virials = atoms.info.get(virials_key, None)
     dipole = atoms.info.get(dipole_key, None)  # Debye
     magmom = atoms.arrays.get("dft_magmom", None)
+    magforces = atoms.arrays.get(magforces_key, None)
+    #print("magforces: ", magforces)
     # Charges default to 0 instead of None if not found
     charges = atoms.arrays.get(charges_key, np.zeros(len(atoms)))  # atomic unit
     atomic_numbers = np.array(
@@ -156,6 +164,7 @@ def config_from_atoms(
     forces_weight = atoms.info.get("config_forces_weight", 1.0)
     stress_weight = atoms.info.get("config_stress_weight", 1.0)
     virials_weight = atoms.info.get("config_virials_weight", 1.0)
+    magforces_weight = atoms.info.get("config_magforces_weight", 1.0)
 
     head = atoms.info.get(head_key, "Default")
 
@@ -180,6 +189,7 @@ def config_from_atoms(
         atomic_numbers=atomic_numbers,
         positions=atoms.get_positions(),
         magmom=magmom,
+        magforces=magforces,
         energy=energy,
         forces=forces,
         stress=stress,
@@ -192,6 +202,7 @@ def config_from_atoms(
         forces_weight=forces_weight,
         stress_weight=stress_weight,
         virials_weight=virials_weight,
+        magforces_weight=magforces_weight,
         config_type=config_type,
         pbc=pbc,
         cell=cell,
@@ -224,6 +235,7 @@ def load_from_xyz(
     virials_key: str = "REF_virials",
     dipole_key: str = "REF_dipole",
     charges_key: str = "REF_charges",
+    magforces_key: str = "REF_magforces",
     head_key: str = "head",
     head_name: str = "Default",
     extract_atomic_energies: bool = False,
@@ -303,6 +315,7 @@ def load_from_xyz(
         virials_key=virials_key,
         dipole_key=dipole_key,
         charges_key=charges_key,
+        magforces_key=magforces_key,
         head_key=head_key,
     )
     return atomic_energies_dict, configs

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -21,6 +21,7 @@ Forces = np.ndarray  # [..., 3]
 Stress = np.ndarray  # [6, ], [3,3], [9, ]
 Virials = np.ndarray  # [6, ], [3,3], [9, ]
 Charges = np.ndarray  # [..., 1]
+Magmom = np.ndarray  # [..., 3]
 Cell = np.ndarray  # [3,3]
 Pbc = tuple  # (3,)
 
@@ -38,6 +39,7 @@ class Configuration:
     virials: Optional[Virials] = None  # eV
     dipole: Optional[Vector] = None  # Debye
     charges: Optional[Charges] = None  # atomic unit
+    magmom: Optional[Magmom] = None
     cell: Optional[Cell] = None
     pbc: Optional[Pbc] = None
 
@@ -46,6 +48,7 @@ class Configuration:
     forces_weight: float = 1.0  # weight of config forces in loss
     stress_weight: float = 1.0  # weight of config stress in loss
     virials_weight: float = 1.0  # weight of config virial in loss
+    magmom_weight: float = 1.0  # weight of config virial in loss
     config_type: Optional[str] = DEFAULT_CONFIG_TYPE  # config_type of config
     head: Optional[str] = "Default"  # head used to compute the config
 

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -140,6 +140,7 @@ def config_from_atoms(
     stress = atoms.info.get(stress_key, None)  # eV / Ang ^ 3
     virials = atoms.info.get(virials_key, None)
     dipole = atoms.info.get(dipole_key, None)  # Debye
+    magmom = atoms.arrays.get("dft_magmom", None)
     # Charges default to 0 instead of None if not found
     charges = atoms.arrays.get(charges_key, np.zeros(len(atoms)))  # atomic unit
     atomic_numbers = np.array(
@@ -178,6 +179,7 @@ def config_from_atoms(
     return Configuration(
         atomic_numbers=atomic_numbers,
         positions=atoms.get_positions(),
+        magmom=magmom,
         energy=energy,
         forces=forces,
         stress=stress,

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -98,6 +98,7 @@ def config_from_atoms_list(
     virials_key="REF_virials",
     dipole_key="REF_dipole",
     charges_key="REF_charges",
+    magmom_key="REF_magmom",
     magforces_key="REF_magforces",
     head_key="head",
     config_type_weights: Optional[Dict[str, float]] = None,
@@ -117,6 +118,7 @@ def config_from_atoms_list(
                 virials_key=virials_key,
                 dipole_key=dipole_key,
                 charges_key=charges_key,
+                magmom_key=magmom_key,
                 magforces_key=magforces_key,
                 head_key=head_key,
                 config_type_weights=config_type_weights,
@@ -133,6 +135,7 @@ def config_from_atoms(
     virials_key="REF_virials",
     dipole_key="REF_dipole",
     charges_key="REF_charges",
+    magmom_key="REF_magmom",
     magforces_key="REF_magforces",
     head_key="head",
     config_type_weights: Optional[Dict[str, float]] = None,
@@ -146,7 +149,7 @@ def config_from_atoms(
     stress = atoms.info.get(stress_key, None)  # eV / Ang ^ 3
     virials = atoms.info.get(virials_key, None)
     dipole = atoms.info.get(dipole_key, None)  # Debye
-    magmom = atoms.arrays.get("dft_magmom", None)
+    magmom = atoms.arrays.get(magmom_key, None)
     magforces = atoms.arrays.get(magforces_key, None)
     #print("magforces: ", magforces)
     # Charges default to 0 instead of None if not found
@@ -195,6 +198,7 @@ def config_from_atoms(
         stress=stress,
         virials=virials,
         dipole=dipole,
+        
         charges=charges,
         weight=weight,
         head=head,
@@ -235,6 +239,7 @@ def load_from_xyz(
     virials_key: str = "REF_virials",
     dipole_key: str = "REF_dipole",
     charges_key: str = "REF_charges",
+    magmom_key: str = "REF_magmom",
     magforces_key: str = "REF_magforces",
     head_key: str = "head",
     head_name: str = "Default",
@@ -315,6 +320,7 @@ def load_from_xyz(
         virials_key=virials_key,
         dipole_key=dipole_key,
         charges_key=charges_key,
+        magmom_key=magmom_key,
         magforces_key=magforces_key,
         head_key=head_key,
     )

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -47,7 +47,7 @@ from .models import (
     ScaleShiftBOTNet,
     ScaleShiftMACE,
     #
-    MagneticEqMACE,
+    MagneticSCFMACE,
     MagneticScaleShiftMACE,
     MagneticSolidHarmonicsSpinOrbitCoupledScaleShiftMACE,
     MagneticSolidHarmonicsScaleShiftMACE,
@@ -55,6 +55,9 @@ from .models import (
     MagneticSolidHarmonicsSeparateReadoutMixMagmomScaleShiftMACE,
     MagneticSolidHarmonicsFlexibleSOScaleShiftMACE,
     MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE
 )
 from .radial import BesselBasis, GaussianBasis, PolynomialCutoff, ZBLBasis
 from .symmetric_contraction import SymmetricContraction

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -27,6 +27,7 @@ from .blocks import (
     MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock,
     MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock,
     ResidualElementDependentInteractionBlock,
+    MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock,
     ScaleShiftBlock,
 )
 from .loss import (
@@ -86,6 +87,7 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "MagneticRealAgnosticSeparateRadialDensityTestingInteractionBlock": MagneticRealAgnosticSeparateRadialDensityTestingInteractionBlock,
     "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock,
     "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock,
+    "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock,
 }
 
 scaling_classes: Dict[str, Callable] = {

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -39,6 +39,7 @@ from .models import (
     EnergyDipolesMACE,
     ScaleShiftBOTNet,
     ScaleShiftMACE,
+    MagneticScaleShiftMACE
 )
 from .radial import BesselBasis, GaussianBasis, PolynomialCutoff, ZBLBasis
 from .symmetric_contraction import SymmetricContraction
@@ -96,6 +97,7 @@ __all__ = [
     "ScaleShiftBOTNet",
     "AtomicDipolesMACE",
     "EnergyDipolesMACE",
+    "MagneticScaleShiftMACE",
     "WeightedEnergyForcesLoss",
     "WeightedForcesLoss",
     "WeightedEnergyForcesVirialsLoss",

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -20,6 +20,7 @@ from .blocks import (
     RealAgnosticInteractionBlock,
     RealAgnosticResidualInteractionBlock,
     MagneticRealAgnosticDensityInteractionBlock,
+    MagneticRealAgnosticSeparateRadialDensityInteractionBlock,
     ResidualElementDependentInteractionBlock,
     ScaleShiftBlock,
 )
@@ -40,7 +41,9 @@ from .models import (
     EnergyDipolesMACE,
     ScaleShiftBOTNet,
     ScaleShiftMACE,
-    MagneticScaleShiftMACE
+    #
+    MagneticScaleShiftMACE,
+    MagneticSolidHarmonicsScaleShiftMACE
 )
 from .radial import BesselBasis, GaussianBasis, PolynomialCutoff, ZBLBasis
 from .symmetric_contraction import SymmetricContraction
@@ -62,7 +65,8 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "RealAgnosticInteractionBlock": RealAgnosticInteractionBlock,
     "RealAgnosticDensityInteractionBlock": RealAgnosticDensityInteractionBlock,
     "RealAgnosticDensityResidualInteractionBlock": RealAgnosticDensityResidualInteractionBlock,
-    "MagneticRealAgnosticDensityInteractionBlock": MagneticRealAgnosticDensityInteractionBlock
+    "MagneticRealAgnosticDensityInteractionBlock": MagneticRealAgnosticDensityInteractionBlock,
+    "MagneticRealAgnosticSeparateRadialDensityInteractionBlock": MagneticRealAgnosticSeparateRadialDensityInteractionBlock,
 }
 
 scaling_classes: Dict[str, Callable] = {
@@ -100,6 +104,7 @@ __all__ = [
     "AtomicDipolesMACE",
     "EnergyDipolesMACE",
     "MagneticScaleShiftMACE",
+    "MagneticSolidHarmonicsScaleShiftMACE",
     "WeightedEnergyForcesLoss",
     "WeightedForcesLoss",
     "WeightedEnergyForcesVirialsLoss",

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -28,6 +28,8 @@ from .blocks import (
     MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock,
     ResidualElementDependentInteractionBlock,
     MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock,
+    MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock,
+    MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock,
     ScaleShiftBlock,
 )
 from .loss import (
@@ -88,6 +90,8 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock,
     "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock,
     "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock,
+    "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock": MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock,
+    "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock": MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock,
 }
 
 scaling_classes: Dict[str, Callable] = {

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -19,6 +19,7 @@ from .blocks import (
     RealAgnosticDensityResidualInteractionBlock,
     RealAgnosticInteractionBlock,
     RealAgnosticResidualInteractionBlock,
+    MagneticRealAgnosticDensityInteractionBlock,
     ResidualElementDependentInteractionBlock,
     ScaleShiftBlock,
 )
@@ -61,6 +62,7 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "RealAgnosticInteractionBlock": RealAgnosticInteractionBlock,
     "RealAgnosticDensityInteractionBlock": RealAgnosticDensityInteractionBlock,
     "RealAgnosticDensityResidualInteractionBlock": RealAgnosticDensityResidualInteractionBlock,
+    "MagneticRealAgnosticDensityInteractionBlock": MagneticRealAgnosticDensityInteractionBlock
 }
 
 scaling_classes: Dict[str, Callable] = {

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -21,6 +21,11 @@ from .blocks import (
     RealAgnosticResidualInteractionBlock,
     MagneticRealAgnosticDensityInteractionBlock,
     MagneticRealAgnosticSeparateRadialDensityInteractionBlock,
+    MagneticRealAgnosticSeparateRadialCoupledDensityInteractionBlock,
+    MagneticRealAgnosticSeparateRadialCoupledPosToMagDensityInteractionBlock,
+    MagneticRealAgnosticSeparateRadialDensityTestingInteractionBlock,
+    MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock,
+    MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock,
     ResidualElementDependentInteractionBlock,
     ScaleShiftBlock,
 )
@@ -43,7 +48,12 @@ from .models import (
     ScaleShiftMACE,
     #
     MagneticScaleShiftMACE,
-    MagneticSolidHarmonicsScaleShiftMACE
+    MagneticSolidHarmonicsSpinOrbitCoupledScaleShiftMACE,
+    MagneticSolidHarmonicsScaleShiftMACE,
+    MagneticSolidHarmonicsSeparateReadoutScaleShiftMACE,
+    MagneticSolidHarmonicsSeparateReadoutMixMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsFlexibleSOScaleShiftMACE,
+    MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE,
 )
 from .radial import BesselBasis, GaussianBasis, PolynomialCutoff, ZBLBasis
 from .symmetric_contraction import SymmetricContraction
@@ -67,6 +77,11 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "RealAgnosticDensityResidualInteractionBlock": RealAgnosticDensityResidualInteractionBlock,
     "MagneticRealAgnosticDensityInteractionBlock": MagneticRealAgnosticDensityInteractionBlock,
     "MagneticRealAgnosticSeparateRadialDensityInteractionBlock": MagneticRealAgnosticSeparateRadialDensityInteractionBlock,
+    "MagneticRealAgnosticSeparateRadialCoupledDensityInteractionBlock": MagneticRealAgnosticSeparateRadialCoupledDensityInteractionBlock,
+    "MagneticRealAgnosticSeparateRadialCoupledPosToMagDensityInteractionBlock": MagneticRealAgnosticSeparateRadialCoupledPosToMagDensityInteractionBlock,
+    "MagneticRealAgnosticSeparateRadialDensityTestingInteractionBlock": MagneticRealAgnosticSeparateRadialDensityTestingInteractionBlock,
+    "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock,
+    "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock,
 }
 
 scaling_classes: Dict[str, Callable] = {
@@ -105,6 +120,7 @@ __all__ = [
     "EnergyDipolesMACE",
     "MagneticScaleShiftMACE",
     "MagneticSolidHarmonicsScaleShiftMACE",
+    "MagneticSolidHarmonicsSpinOrbitCoupledScaleShiftMACE",
     "WeightedEnergyForcesLoss",
     "WeightedForcesLoss",
     "WeightedEnergyForcesVirialsLoss",

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -47,6 +47,7 @@ from .models import (
     ScaleShiftBOTNet,
     ScaleShiftMACE,
     #
+    MagneticEqMACE,
     MagneticScaleShiftMACE,
     MagneticSolidHarmonicsSpinOrbitCoupledScaleShiftMACE,
     MagneticSolidHarmonicsScaleShiftMACE,

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -42,6 +42,7 @@ from .loss import (
     WeightedEnergyForcesVirialsLoss,
     WeightedForcesLoss,
     WeightedHuberEnergyForcesStressLoss,
+    EvenSpline1BodyLoss,
 )
 from .models import (
     MACE,
@@ -64,7 +65,12 @@ from .models import (
     MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE,
     MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE,
     MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE,
-    MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE
+    MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesFixingGinzburgSelfMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomFixingScaleShiftMACE,
+    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesEvenSplineSelfMagmomScaleShiftMACE,
+    #
+    EvenMagSaturationBarrier
 )
 
 from .radial import BesselBasis, GaussianBasis, PolynomialCutoff, ZBLBasis
@@ -145,6 +151,7 @@ __all__ = [
     "WeightedEnergyForcesDipoleLoss",
     "WeightedHuberEnergyForcesStressLoss",
     "UniversalLoss",
+    "EvenSpline1BodyLoss",
     "SymmetricContraction",
     "NonSOCSymmetricContraction",
     "interaction_classes",

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -31,6 +31,8 @@ from .blocks import (
     MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock,
     MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock,
     MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock,
+    MagneticRealAgnosticSpinOrbitCoupledDensityWithMagmomInteractionBlock,
+    MagneticRealAgnosticResidueSpinOrbitCoupledDensityWithMagmomInteractionBlock,
     ScaleShiftBlock,
 )
 from .loss import (
@@ -104,6 +106,9 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock": MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock,
     "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock": MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock,
     "MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock,
+    "MagneticRealAgnosticSpinOrbitCoupledDensityWithMagmomInteractionBlock": MagneticRealAgnosticSpinOrbitCoupledDensityWithMagmomInteractionBlock,
+    "MagneticRealAgnosticResidueSpinOrbitCoupledDensityWithMagmomInteractionBlock": MagneticRealAgnosticResidueSpinOrbitCoupledDensityWithMagmomInteractionBlock,
+
 }
 
 scaling_classes: Dict[str, Callable] = {

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -30,6 +30,7 @@ from .blocks import (
     MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock,
     MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock,
     MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock,
+    MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock,
     ScaleShiftBlock,
 )
 from .loss import (
@@ -61,10 +62,13 @@ from .models import (
     MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE,
     MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE,
     MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE,
-    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE
+    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE
 )
+
 from .radial import BesselBasis, GaussianBasis, PolynomialCutoff, ZBLBasis
-from .symmetric_contraction import SymmetricContraction
+from .symmetric_contraction import SymmetricContraction, NonSOCSymmetricContraction
 from .utils import (
     compute_avg_num_neighbors,
     compute_fixed_charge_dipole,
@@ -93,6 +97,7 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock,
     "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock": MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock,
     "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock": MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock,
+    "MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock": MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock,
 }
 
 scaling_classes: Dict[str, Callable] = {
@@ -141,6 +146,7 @@ __all__ = [
     "WeightedHuberEnergyForcesStressLoss",
     "UniversalLoss",
     "SymmetricContraction",
+    "NonSOCSymmetricContraction",
     "interaction_classes",
     "compute_mean_std_atomic_inter_energy",
     "compute_avg_num_neighbors",

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -1,6 +1,10 @@
+import logging
 from typing import Callable, Dict, Optional, Type
 
 import torch
+
+logging.getLogger("cuequivariance_torch.primitives.tensor_product").setLevel(logging.WARNING)
+logging.getLogger("cuequivariance_torch.primitives.symmetric_tensor_product").setLevel(logging.WARNING)
 
 from .blocks import (
     AgnosticNonlinearInteractionBlock,

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -60,7 +60,8 @@ from .models import (
     MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE,
     MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE,
     MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE,
-    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE
+    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE,
+    MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE
 )
 from .radial import BesselBasis, GaussianBasis, PolynomialCutoff, ZBLBasis
 from .symmetric_contraction import SymmetricContraction

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -256,17 +256,21 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         use_sc: bool = True,
         num_elements: Optional[int] = None,
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        contraction_cls: Optional[str] = "SymmetricContraction"
     ) -> None:
         super().__init__()
 
         self.use_sc = use_sc
-        self.symmetric_contractions = SymmetricContractionWrapper(
-            irreps_in=node_feats_irreps,
-            irreps_out=target_irreps,
-            correlation=correlation,
-            num_elements=num_elements,
-            cueq_config=cueq_config,
-        )
+        if contraction_cls == "SymmetricContraction":
+            self.symmetric_contractions = SymmetricContractionWrapper(
+                irreps_in=node_feats_irreps,
+                irreps_out=target_irreps,
+                correlation=correlation,
+                num_elements=num_elements,
+                cueq_config=cueq_config,
+            )
+        else:
+            raise ValueError("Contraction class not supported")
         # Update linear
         self.linear = Linear(
             target_irreps,

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -1495,6 +1495,147 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
         )  # [n_nodes, channels, (lmax + 1)**2]
 
 
+@compile_mode("script")
+class MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock(MagneticInteractionBlock):
+    def _setup(self) -> None:
+        if not hasattr(self, "cueq_config"):
+            self.cueq_config = None
+
+        print("into MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock")
+        # First linear
+        self.linear_up = Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+        print("===done init linear===")
+        # TensorProduct for real space
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+        print("===done init conv_tp===")
+        # TensorProduct in magnetic moment space
+        magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(
+            #self.conv_tp.irreps_out,
+            irreps_mid,
+            self.magmom_node_attrs_irreps,
+            self.target_irreps,
+        )
+        self.magmom_conv_tp = TensorProduct(
+            self.conv_tp.irreps_out,
+            self.magmom_node_attrs_irreps,
+            magmom_irreps_mid,
+            instructions=magmom_instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+        print("===done init magmom conv_tp===")
+        # Convolution weights 
+        input_dim = self.edge_feats_irreps.num_irreps
+        magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + self.radial_MLP + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+        # transforming from radial l channels to magnetic l channels
+        self.conv_tp_weights_magmom = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim, ] + [self.magmom_conv_tp.weight_numel, ]
+        )
+
+        # Linear
+        self.irreps_out = self.target_irreps
+
+        self.magmom_linear = Linear(
+            self.magmom_conv_tp.irreps_out,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+        self.magmom_skip_tp = FullyConnectedTensorProduct(
+            self.irreps_out,
+            self.node_attrs_irreps,
+            self.irreps_out,
+            cueq_config=self.cueq_config,
+        )
+
+        # Density normalization
+        self.density_fn = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim]
+            + [
+                1,
+            ],
+            torch.nn.functional.silu,
+        )
+        # Reshape
+        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor, # (n_edges, n_basis)
+        edge_index: torch.Tensor,
+        magmom_node_inv_feats: torch.Tensor,
+        magmom_node_attrs: torch.Tensor
+    ) -> Tuple[torch.Tensor, None]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        
+        num_nodes = node_feats.shape[0]
+        node_feats = self.linear_up(node_feats)
+        
+        # boardcast node feats to number of nodes
+        magmom_inv_feats_j = magmom_node_inv_feats[sender]
+        
+        edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
+        
+        # combined learnable radial
+        tp_weights = self.conv_tp_weights(edge_feats_with_magmom)
+
+        # density normalization
+        edge_density = torch.tanh(self.density_fn(edge_feats_with_magmom) ** 2)
+
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        
+        tp_weights_magmom = self.conv_tp_weights_magmom(edge_feats_with_magmom)
+        
+        magmom_mji = self.magmom_conv_tp(
+            mji, magmom_node_attrs[sender], tp_weights_magmom
+        )  # [n_edges, irreps]
+        
+        density = scatter_sum(
+            src=edge_density, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, 1]
+        
+        magmom_message = scatter_sum(
+            src=magmom_mji, index=receiver, dim = 0, dim_size=num_nodes,
+        )
+
+        magmom_message = self.magmom_linear(magmom_message) / (density + 1)
+        magmom_message = self.magmom_skip_tp(magmom_message, node_attrs)
+        return (
+            self.reshape(magmom_message),
+            None,
+        )  # [n_nodes, channels, (lmax + 1)**2]
+
 
 @compile_mode("script")
 class MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock(MagneticInteractionBlock):
@@ -1624,6 +1765,160 @@ class MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock(Magneti
 
         # density normalization
         edge_density = torch.tanh(self.density_fn(edge_feats) ** 2)
+
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        
+        tp_weights_magmom = self.conv_tp_weights_magmom(edge_feats_with_magmom)
+        
+        magmom_mji = self.magmom_conv_tp(
+            mji, magmom_node_attrs[sender], tp_weights_magmom
+        )  # [n_edges, irreps]
+        
+        density = scatter_sum(
+            src=edge_density, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, 1]
+        
+        magmom_message = scatter_sum(
+            src=magmom_mji, index=receiver, dim=0, dim_size=num_nodes,
+        )
+
+        magmom_message = self.magmom_linear(magmom_message) / (density + 1)
+
+        return (
+            self.reshape(magmom_message),
+            sc,
+        )  # [n_nodes, channels, (lmax + 1)**2]
+
+@compile_mode("script")
+class MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock(MagneticInteractionBlock):
+    def _setup(self) -> None:
+        if not hasattr(self, "cueq_config"):
+            self.cueq_config = None
+
+        # First linear
+        self.linear_up = Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+
+        # TensorProduct for real space
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+
+        # TensorProduct in magnetic moment space
+        magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(
+            #self.conv_tp.irreps_out,
+            irreps_mid,
+            self.magmom_node_attrs_irreps,
+            self.target_irreps,
+        )
+        self.magmom_conv_tp = TensorProduct(
+            self.conv_tp.irreps_out,
+            self.magmom_node_attrs_irreps,
+            magmom_irreps_mid,
+            instructions=magmom_instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+        
+        # Convolution weights 
+        input_dim = self.edge_feats_irreps.num_irreps
+        magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + self.radial_MLP + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+        # transforming from radial l channels to magnetic l channels
+        self.conv_tp_weights_magmom = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim, ] + [self.magmom_conv_tp.weight_numel, ]
+        )
+
+        # Linear
+        self.irreps_out = self.target_irreps
+
+        self.magmom_linear = Linear(
+            self.magmom_conv_tp.irreps_out,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+        # self.magmom_skip_tp = FullyConnectedTensorProduct(
+        #     self.irreps_out,
+        #     self.node_attrs_irreps,
+        #     self.irreps_out,
+        #     cueq_config=self.cueq_config,
+        # )
+
+        # Selector TensorProduct
+        self.skip_tp = FullyConnectedTensorProduct(
+            self.node_feats_irreps,
+            self.node_attrs_irreps,
+            self.hidden_irreps,
+            cueq_config=self.cueq_config,
+        )
+
+        # Density normalization
+        self.density_fn = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim]
+            + [
+                1,
+            ],
+            torch.nn.functional.silu,
+        )
+        # Reshape
+        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor, # (n_edges, n_basis)
+        edge_index: torch.Tensor,
+        magmom_node_inv_feats: torch.Tensor,
+        magmom_node_attrs: torch.Tensor
+    ) -> Tuple[torch.Tensor, None]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        
+        num_nodes = node_feats.shape[0]
+
+        # residue connection
+        sc = self.skip_tp(node_feats, node_attrs)
+
+        #
+        node_feats = self.linear_up(node_feats)
+        
+        # boardcast node feats to number of nodes
+        magmom_inv_feats_j = magmom_node_inv_feats[sender]
+
+        edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
+        
+        # combined learnable radial
+        tp_weights = self.conv_tp_weights(edge_feats_with_magmom)
+
+        # density normalization
+        edge_density = torch.tanh(self.density_fn(edge_feats_with_magmom) ** 2)
 
         mji = self.conv_tp(
             node_feats[sender], edge_attrs, tp_weights

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -373,12 +373,12 @@ class EquivariantProductBasisWithSelfMagmomBlock(torch.nn.Module):
 
         # interaction with self magnetic moment
         irreps_mid, instructions = tp_out_irreps_with_instructions(
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
             self.magmom_node_attrs_irreps,
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
         )
         self.conv_tp = TensorProduct(
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
             self.magmom_node_attrs_irreps,
             irreps_mid,
             instructions=instructions,
@@ -391,21 +391,18 @@ class EquivariantProductBasisWithSelfMagmomBlock(torch.nn.Module):
             [magmom_input_dim] + [64, 64, 64] + [self.conv_tp.weight_numel],
             torch.nn.functional.silu,
         )
-        # self.conv_tp_weights =  nn.FullyConnectedNet(
-        #     [magmom_input_dim] + [self.conv_tp.weight_numel],
-        #     None,
-        # )
+        
         # Update linear
         self.linear = Linear(
             self.conv_tp.irreps_out,
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
             internal_weights=True,
             shared_weights=True,
             cueq_config=cueq_config,
         )
         self.linear_ori = Linear(
-            target_irreps,
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
+            o3.Irreps(str(target_irreps)),
             internal_weights=True,
             shared_weights=True,
             cueq_config=cueq_config,
@@ -1294,8 +1291,7 @@ class MagneticRealAgnosticDensityInteractionBlock(MagneticInteractionBlock):
     ) -> Tuple[torch.Tensor, None]:
         sender = edge_index[0]
         receiver = edge_index[1]
-        #print("edge index shape: ", edge_index.shape)
-        #print("magmom_node_attrs: ", magmom_node_attrs)
+        
         num_nodes = node_feats.shape[0]
         node_feats = self.linear_up(node_feats)
 
@@ -1456,6 +1452,7 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
         
         # boardcast node feats to number of nodes
         magmom_inv_feats_j = magmom_node_inv_feats[sender]
+        
         edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
         
         # combined learnable radial
@@ -1490,6 +1487,161 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
             None,
         )  # [n_nodes, channels, (lmax + 1)**2]
 
+
+
+@compile_mode("script")
+class MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock(MagneticInteractionBlock):
+    def _setup(self) -> None:
+        if not hasattr(self, "cueq_config"):
+            self.cueq_config = None
+
+        # First linear
+        self.linear_up = Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+
+        # TensorProduct for real space
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+
+        # TensorProduct in magnetic moment space
+        magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(
+            #self.conv_tp.irreps_out,
+            irreps_mid,
+            self.magmom_node_attrs_irreps,
+            self.target_irreps,
+        )
+        self.magmom_conv_tp = TensorProduct(
+            self.conv_tp.irreps_out,
+            self.magmom_node_attrs_irreps,
+            magmom_irreps_mid,
+            instructions=magmom_instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+        
+        # Convolution weights 
+        input_dim = self.edge_feats_irreps.num_irreps
+        magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + self.radial_MLP + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+        # transforming from radial l channels to magnetic l channels
+        self.conv_tp_weights_magmom = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim, ] + [self.magmom_conv_tp.weight_numel, ]
+        )
+
+        # Linear
+        self.irreps_out = self.target_irreps
+
+        self.magmom_linear = Linear(
+            self.magmom_conv_tp.irreps_out,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+        self.magmom_skip_tp = FullyConnectedTensorProduct(
+            self.irreps_out,
+            self.node_attrs_irreps,
+            self.irreps_out,
+            cueq_config=self.cueq_config,
+        )
+
+        # Selector TensorProduct
+        self.skip_tp = FullyConnectedTensorProduct(
+            self.node_feats_irreps,
+            self.node_attrs_irreps,
+            self.hidden_irreps,
+            cueq_config=self.cueq_config,
+        )
+
+        # Density normalization
+        self.density_fn = nn.FullyConnectedNet(
+            [input_dim]
+            + [
+                1,
+            ],
+            torch.nn.functional.silu,
+        )
+        # Reshape
+        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor, # (n_edges, n_basis)
+        edge_index: torch.Tensor,
+        magmom_node_inv_feats: torch.Tensor,
+        magmom_node_attrs: torch.Tensor
+    ) -> Tuple[torch.Tensor, None]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        
+        num_nodes = node_feats.shape[0]
+
+        # residue connection
+        sc = self.skip_tp(node_feats, node_attrs)
+
+        #
+        node_feats = self.linear_up(node_feats)
+        
+        # boardcast node feats to number of nodes
+        magmom_inv_feats_j = magmom_node_inv_feats[sender]
+
+        edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
+        
+        # combined learnable radial
+        tp_weights = self.conv_tp_weights(edge_feats_with_magmom)
+
+        # density normalization
+        edge_density = torch.tanh(self.density_fn(edge_feats) ** 2)
+
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        
+        tp_weights_magmom = self.conv_tp_weights_magmom(edge_feats_with_magmom)
+        
+        magmom_mji = self.magmom_conv_tp(
+            mji, magmom_node_attrs[sender], tp_weights_magmom
+        )  # [n_edges, irreps]
+        
+        density = scatter_sum(
+            src=edge_density, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, 1]
+        
+        magmom_message = scatter_sum(
+            src=magmom_mji, index=receiver, dim = 0, dim_size=num_nodes,
+        )
+
+        magmom_message = self.magmom_linear(magmom_message) / (density + 1)
+
+        return (
+            self.reshape(magmom_message),
+            sc,
+        )  # [n_nodes, channels, (lmax + 1)**2]
 
 @compile_mode("script")
 class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(MagneticInteractionBlock):
@@ -1613,7 +1765,6 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
         num_edges = len(sender)
         num_k = self.conv_tp.irreps_out[0].mul
         lmax_magmom = self.magmom_node_attrs_irreps.lmax
-        #print("num_k:", num_k)
 
         num_nodes = node_feats.shape[0]
         node_feats = self.linear_up(node_feats)
@@ -2452,6 +2603,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
         edge_feats: torch.Tensor,
         edge_index: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+
         sender = edge_index[0]
         receiver = edge_index[1]
         num_nodes = node_feats.shape[0]

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -1452,8 +1452,7 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
         
         # boardcast node feats to number of nodes
         magmom_inv_feats_j = magmom_node_inv_feats[sender]
-        print("edge_feats.shape: ", edge_feats.shape)
-        print("magmom_inv_feats_j.shape: ", magmom_inv_feats_j.shape)
+        
         edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
         
         # combined learnable radial
@@ -1488,6 +1487,161 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
             None,
         )  # [n_nodes, channels, (lmax + 1)**2]
 
+
+
+@compile_mode("script")
+class MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock(MagneticInteractionBlock):
+    def _setup(self) -> None:
+        if not hasattr(self, "cueq_config"):
+            self.cueq_config = None
+
+        # First linear
+        self.linear_up = Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+
+        # TensorProduct for real space
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+
+        # TensorProduct in magnetic moment space
+        magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(
+            #self.conv_tp.irreps_out,
+            irreps_mid,
+            self.magmom_node_attrs_irreps,
+            self.target_irreps,
+        )
+        self.magmom_conv_tp = TensorProduct(
+            self.conv_tp.irreps_out,
+            self.magmom_node_attrs_irreps,
+            magmom_irreps_mid,
+            instructions=magmom_instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+        
+        # Convolution weights 
+        input_dim = self.edge_feats_irreps.num_irreps
+        magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + self.radial_MLP + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+        # transforming from radial l channels to magnetic l channels
+        self.conv_tp_weights_magmom = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim, ] + [self.magmom_conv_tp.weight_numel, ]
+        )
+
+        # Linear
+        self.irreps_out = self.target_irreps
+
+        self.magmom_linear = Linear(
+            self.magmom_conv_tp.irreps_out,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+        self.magmom_skip_tp = FullyConnectedTensorProduct(
+            self.irreps_out,
+            self.node_attrs_irreps,
+            self.irreps_out,
+            cueq_config=self.cueq_config,
+        )
+
+        # Selector TensorProduct
+        self.skip_tp = FullyConnectedTensorProduct(
+            self.node_feats_irreps,
+            self.node_attrs_irreps,
+            self.hidden_irreps,
+            cueq_config=self.cueq_config,
+        )
+
+        # Density normalization
+        self.density_fn = nn.FullyConnectedNet(
+            [input_dim]
+            + [
+                1,
+            ],
+            torch.nn.functional.silu,
+        )
+        # Reshape
+        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor, # (n_edges, n_basis)
+        edge_index: torch.Tensor,
+        magmom_node_inv_feats: torch.Tensor,
+        magmom_node_attrs: torch.Tensor
+    ) -> Tuple[torch.Tensor, None]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        
+        num_nodes = node_feats.shape[0]
+
+        # residue connection
+        sc = self.skip_tp(node_feats, node_attrs)
+
+        #
+        node_feats = self.linear_up(node_feats)
+        
+        # boardcast node feats to number of nodes
+        magmom_inv_feats_j = magmom_node_inv_feats[sender]
+
+        edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
+        
+        # combined learnable radial
+        tp_weights = self.conv_tp_weights(edge_feats_with_magmom)
+
+        # density normalization
+        edge_density = torch.tanh(self.density_fn(edge_feats) ** 2)
+
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        
+        tp_weights_magmom = self.conv_tp_weights_magmom(edge_feats_with_magmom)
+        
+        magmom_mji = self.magmom_conv_tp(
+            mji, magmom_node_attrs[sender], tp_weights_magmom
+        )  # [n_edges, irreps]
+        
+        density = scatter_sum(
+            src=edge_density, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, 1]
+        
+        magmom_message = scatter_sum(
+            src=magmom_mji, index=receiver, dim = 0, dim_size=num_nodes,
+        )
+
+        magmom_message = self.magmom_linear(magmom_message) / (density + 1)
+
+        return (
+            self.reshape(magmom_message),
+            sc,
+        )  # [n_nodes, channels, (lmax + 1)**2]
 
 @compile_mode("script")
 class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(MagneticInteractionBlock):
@@ -1611,7 +1765,6 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
         num_edges = len(sender)
         num_k = self.conv_tp.irreps_out[0].mul
         lmax_magmom = self.magmom_node_attrs_irreps.lmax
-        #print("num_k:", num_k)
 
         num_nodes = node_feats.shape[0]
         node_feats = self.linear_up(node_feats)
@@ -2450,6 +2603,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
         edge_feats: torch.Tensor,
         edge_index: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+
         sender = edge_index[0]
         receiver = edge_index[1]
         num_nodes = node_feats.shape[0]

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -438,9 +438,14 @@ class EquivariantProductBasisWithSelfMagmomBlock(torch.nn.Module):
 
         # interaction with magnectic moment
         tp_weights = self.conv_tp_weights(magmom_node_inv_feats)
-
+        # print("magmom_node_inv_feats: ", magmom_node_inv_feats)
+        # print("tp_weights:", tp_weights)
         out = self.conv_tp(node_feats, magmom_node_attrs, tp_weights)
-        
+        # print("node_feats:", node_feats)
+        # print("magmom_node_attrs:", magmom_node_attrs)
+        # print("out: ", out)
+        # print(torch.norm(self.linear(out)))
+        # print(torch.norm(self.linear_ori(node_feats)))
         # out = node_feats
         if self.use_sc and sc is not None:
             out_message = self.linear(out) + self.linear_ori(node_feats) + sc
@@ -573,6 +578,9 @@ class EquivariantProductBasisWithOneBodySelfMagmomBlock(torch.nn.Module):
         else:
             out[:, :, 0] += magmom_lenghts.unsqueeze(-1) * self.onebody_magmombasis(magmom_node_inv_feats)
 
+        # print(torch.norm(self.linear(out)))
+        # print(torch.norm(self.linear_ori(node_feats)))
+        # print(torch.norm(sc))
         # out = node_feats
         if self.use_sc and sc is not None:
             out_message = self.linear(out) + self.linear_ori(node_feats) + sc
@@ -1479,7 +1487,6 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
             src=magmom_mji, index=receiver, dim = 0, dim_size=num_nodes,
         )
 
-        # not doing density normalization for now
         magmom_message = self.magmom_linear(magmom_message) / (density + 1)
         magmom_message = self.magmom_skip_tp(magmom_message, node_attrs)
         return (
@@ -1559,12 +1566,12 @@ class MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock(Magneti
             shared_weights=True,
             cueq_config=self.cueq_config,
         )
-        self.magmom_skip_tp = FullyConnectedTensorProduct(
-            self.irreps_out,
-            self.node_attrs_irreps,
-            self.irreps_out,
-            cueq_config=self.cueq_config,
-        )
+        # self.magmom_skip_tp = FullyConnectedTensorProduct(
+        #     self.irreps_out,
+        #     self.node_attrs_irreps,
+        #     self.irreps_out,
+        #     cueq_config=self.cueq_config,
+        # )
 
         # Selector TensorProduct
         self.skip_tp = FullyConnectedTensorProduct(
@@ -1633,7 +1640,7 @@ class MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock(Magneti
         )  # [n_nodes, 1]
         
         magmom_message = scatter_sum(
-            src=magmom_mji, index=receiver, dim = 0, dim_size=num_nodes,
+            src=magmom_mji, index=receiver, dim=0, dim_size=num_nodes,
         )
 
         magmom_message = self.magmom_linear(magmom_message) / (density + 1)

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -1026,7 +1026,8 @@ class MagneticRealAgnosticDensityInteractionBlock(MagneticInteractionBlock):
         node_feats = self.linear_up(node_feats)
         # boardcast node feats to number of nodes
         #magmom_inv_feats_i = magmom_node_inv_feats[sender]
-        magmom_inv_feats_j = magmom_node_inv_feats[receiver]
+        #magmom_inv_feats_j = magmom_node_inv_feats[receiver]
+        magmom_inv_feats_j = magmom_node_inv_feats[sender]
         
         edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)
         tp_weights = self.conv_tp_weights(edge_feats_with_magmom)
@@ -1036,7 +1037,7 @@ class MagneticRealAgnosticDensityInteractionBlock(MagneticInteractionBlock):
         )  # [n_edges, irreps]
 
         magmom_mji = self.magmom_conv_tp(
-            node_feats[sender], magmom_node_attrs[receiver], tp_weights
+            node_feats[sender], magmom_node_attrs[sender], tp_weights
         )  # [n_edges, irreps]
         density = scatter_sum(
             src=edge_density, index=receiver, dim=0, dim_size=num_nodes

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -443,8 +443,7 @@ class EquivariantProductBasisWithSelfMagmomBlock(torch.nn.Module):
         tp_weights = self.conv_tp_weights(magmom_node_inv_feats)
 
         out = self.conv_tp(node_feats, magmom_node_attrs, tp_weights)
-        #print("max out: ", torch.max(out))
-        #print("min out: ", torch.min(out))
+        
         # out = node_feats
         if self.use_sc and sc is not None:
             out_message = self.linear(out) + self.linear_ori(node_feats) + sc

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -373,12 +373,12 @@ class EquivariantProductBasisWithSelfMagmomBlock(torch.nn.Module):
 
         # interaction with self magnetic moment
         irreps_mid, instructions = tp_out_irreps_with_instructions(
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
             self.magmom_node_attrs_irreps,
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
         )
         self.conv_tp = TensorProduct(
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
             self.magmom_node_attrs_irreps,
             irreps_mid,
             instructions=instructions,
@@ -391,21 +391,18 @@ class EquivariantProductBasisWithSelfMagmomBlock(torch.nn.Module):
             [magmom_input_dim] + [64, 64, 64] + [self.conv_tp.weight_numel],
             torch.nn.functional.silu,
         )
-        # self.conv_tp_weights =  nn.FullyConnectedNet(
-        #     [magmom_input_dim] + [self.conv_tp.weight_numel],
-        #     None,
-        # )
+        
         # Update linear
         self.linear = Linear(
             self.conv_tp.irreps_out,
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
             internal_weights=True,
             shared_weights=True,
             cueq_config=cueq_config,
         )
         self.linear_ori = Linear(
-            target_irreps,
-            target_irreps,
+            o3.Irreps(str(target_irreps)),
+            o3.Irreps(str(target_irreps)),
             internal_weights=True,
             shared_weights=True,
             cueq_config=cueq_config,
@@ -1294,8 +1291,7 @@ class MagneticRealAgnosticDensityInteractionBlock(MagneticInteractionBlock):
     ) -> Tuple[torch.Tensor, None]:
         sender = edge_index[0]
         receiver = edge_index[1]
-        #print("edge index shape: ", edge_index.shape)
-        #print("magmom_node_attrs: ", magmom_node_attrs)
+        
         num_nodes = node_feats.shape[0]
         node_feats = self.linear_up(node_feats)
 
@@ -1456,6 +1452,8 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
         
         # boardcast node feats to number of nodes
         magmom_inv_feats_j = magmom_node_inv_feats[sender]
+        print("edge_feats.shape: ", edge_feats.shape)
+        print("magmom_inv_feats_j.shape: ", magmom_inv_feats_j.shape)
         edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
         
         # combined learnable radial

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -311,7 +311,6 @@ class EquivariantProductBasisBlock(torch.nn.Module):
                 irreps_out=target_irreps,
                 correlation=correlation,
                 num_elements=num_elements,
-                cueq_config=cueq_config,
             )
         else:
             raise ValueError("Contraction class not supported")
@@ -323,7 +322,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
             shared_weights=True,
             cueq_config=cueq_config,
         )
-        self.cueq_config = cueq_config
+        self.cueq_config = None if contraction_cls == "NonSOCSymmetricContraction" else cueq_config
 
     def forward(
         self,
@@ -341,7 +340,11 @@ class EquivariantProductBasisBlock(torch.nn.Module):
                     use_cueq = True
                 if self.cueq_config.layout_str == "mul_ir":
                     use_cueq_mul_ir = True
-        if use_cueq:
+        if self.contraction_cls == "NonSOCSymmetricContraction":
+            # Custom non-SOC contraction expects dense one-hot node_attrs and
+            # unflattened equivariant features.
+            node_feats = self.symmetric_contractions(node_feats, node_attrs)
+        elif use_cueq:
             if use_cueq_mul_ir:
                 node_feats = torch.transpose(node_feats, 1, 2)
             index_attrs = torch.nonzero(node_attrs)[:, 1].int()
@@ -375,7 +378,7 @@ class EquivariantProductBasisNonSOCWithSelfMagmomBlock(torch.nn.Module):
         self.use_sc = use_sc
         self.magmom_node_inv_feats_irreps = magmom_node_inv_feats_irreps
         self.magmom_node_attrs_irreps = magmom_node_attrs_irreps
-        self.cueq_config = cueq_config
+        self.cueq_config = None if contraction_cls == "NonSOCSymmetricContraction" else cueq_config
         self.contraction_cls = contraction_cls
         
         if contraction_cls == "SymmetricContraction":
@@ -392,6 +395,7 @@ class EquivariantProductBasisNonSOCWithSelfMagmomBlock(torch.nn.Module):
                 irreps_out=target_irreps,
                 correlation=correlation,
                 num_elements=num_elements,
+                magmom_irreps=self.magmom_node_attrs_irreps,
                 # cueq_config=cueq_config,
             )
         else:
@@ -449,7 +453,11 @@ class EquivariantProductBasisNonSOCWithSelfMagmomBlock(torch.nn.Module):
                     use_cueq = True
                 if self.cueq_config.layout_str == "mul_ir":
                     use_cueq_mul_ir = True
-        if use_cueq:
+        if self.contraction_cls == "NonSOCSymmetricContraction":
+            # Non-SOC contraction is custom and expects dense one-hot attrs and
+            # unflattened equivariant node features.
+            node_feats = self.symmetric_contractions(node_feats, node_attrs)
+        elif use_cueq:
             if use_cueq_mul_ir:
                 node_feats = torch.transpose(node_feats, 1, 2)
             index_attrs = torch.nonzero(node_attrs)[:, 1].int()
@@ -1223,7 +1231,7 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
         )  # [n_nodes, channels, (lmax + 1)**2]
 
 
-@compile_mode("script")
+#@compile_mode("script")
 class RealAgnosticDensityInteractionBlock(InteractionBlock):
     def _setup(self) -> None:
         if not hasattr(self, "cueq_config"):
@@ -2532,7 +2540,6 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
         receiver = edge_index[1]
         num_edges = len(sender)
         num_k = self.conv_tp.irreps_out[0].mul
-        lmax_magmom = self.magmom_node_attrs_irreps.lmax
 
         num_nodes = node_feats.shape[0]
         node_feats = self.linear_up(node_feats)
@@ -2555,7 +2562,14 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
 
         
         tp_weights_magmom = self.conv_tp_weights_magmom(edge_feats_with_magmom)
-        tp_weights_magmom = tp_weights_magmom.reshape(num_edges, num_k, lmax_magmom+1)
+        if tp_weights_magmom.shape[1] % num_k != 0:
+            raise ValueError(
+                "magmom TP weight dimension must be divisible by num_k; "
+                f"got weight_dim={tp_weights_magmom.shape[1]} num_k={num_k}"
+            )
+        tp_weights_magmom = tp_weights_magmom.reshape(
+            num_edges, num_k, tp_weights_magmom.shape[1] // num_k
+        )
         # this is just CP decomposition
         tp_weights_magmom = tp_weights_magmom * pre_mji[:, :num_k].unsqueeze(-1)
         tp_weights_magmom = tp_weights_magmom.reshape(num_edges, tp_weights_magmom.shape[1] * tp_weights_magmom.shape[2])
@@ -2617,7 +2631,7 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
             None
         )  # [n_nodes, channels, (lmax + 1)**2]
 
-@compile_mode("script")
+#@compile_mode("script")
 class MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock(MagneticInteractionBlock):
     """
     Non-SOC interaction block that constructs A_{k k' l l' m m'} = sum_j φ_{k l m}(r_j) φ'_{k' l' m'}(m_j)
@@ -2650,7 +2664,7 @@ class MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock(MagneticInt
             instructions=instr_r,
             shared_weights=False,
             internal_weights=False,
-            cueq_config=self.cueq_config,
+            cueq_config=None,
         )
 
         # --- 3. TensorProduct for magnetic-space (m) message ---
@@ -2666,7 +2680,7 @@ class MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock(MagneticInt
             instructions=instr_m,
             shared_weights=False,
             internal_weights=False,
-            cueq_config=self.cueq_config,
+            cueq_config=None,
         )
 
         # --- 4. MLPs generating radial/magnetic weights ---
@@ -2732,9 +2746,17 @@ class MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock(MagneticInt
 
 
 
-        # --- 7. Density normalization ---
+        # --- 7. Density normalization (mirrors SOC density handling) ---
         self.density_fn = nn.FullyConnectedNet(
-            [input_dim + magmom_input_dim] + [1],
+            [input_dim] + [1],
+            torch.nn.functional.silu,
+        )
+        self.density_fn_magmom = nn.FullyConnectedNet(
+            [magmom_input_dim] + [1],
+            torch.nn.functional.silu,
+        )
+        self.density_gate = nn.FullyConnectedNet(
+            [2, 1],
             torch.nn.functional.silu,
         )
 
@@ -2772,26 +2794,39 @@ class MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock(MagneticInt
         tp_r_weights = self.conv_tp_r_weights(edge_feats_with_magmom)
         tp_m_weights = self.conv_tp_m_weights(edge_feats_with_magmom)
 
-        # --- density normalization term ---
-        edge_density = torch.tanh(self.density_fn(edge_feats_with_magmom) ** 2)
+        # --- density normalization terms (separate radial + magnetic channels) ---
+        edge_density = torch.tanh(self.density_fn(edge_feats) ** 2)
+        edge_density_magmom = torch.tanh(self.density_fn_magmom(magmom_inv_feats_j) ** 2)
 
         # --- compute positional and magnetic edge messages ---
         r_msg = self.conv_tp_r(node_feats[sender], edge_attrs, tp_r_weights)  # φ_{klm}(r_j)
         m_msg = self.conv_tp_m(node_feats[sender], magmom_node_attrs[sender], tp_m_weights)  # φ'_{k'l'm'}(m_j)
         
-        # import pdb; pdb.set_trace();
         r_msg = self.reshape_tp_r_mji(r_msg)
         m_msg = self.reshape_tp_m_mji(m_msg)
         # import pdb; pdb.set_trace();
-        # --- CP-type contraction: pointwise product over (k,k') ---
-        # both r_msg and m_msg: [n_edges, irreps_dim] (same per-edge shape)
-        A_msg = torch.einsum('bkl,bkp->bklp', r_msg, m_msg)  # elementwise CP product = A_{kk'll'mm'}(edge)
+        # --- CP-type contraction: pointwise product over channel index k ---
+        # Layout after reshape_irreps depends on cueq layout:
+        #   mul_ir (default/e3nn): r,m are [B, k, l] and [B, k, p]
+        #   ir_mul (cueq):         r,m are [B, l, k] and [B, p, k]
+        # We always construct A_msg as [B, k, l, p] for downstream code.
+        if (
+            hasattr(self, "cueq_config")
+            and self.cueq_config is not None
+            and getattr(self.cueq_config, "layout_str", "mul_ir") == "ir_mul"
+        ):
+            A_msg = torch.einsum("blk,bpk->bklp", r_msg, m_msg)
+        else:
+            A_msg = torch.einsum("bkl,bkp->bklp", r_msg, m_msg)
 
         # --- aggregate to nodes (sum over j) ---
         pooled_A = scatter_sum(src=A_msg, index=receiver, dim=0, dim_size=num_nodes)
 
-        # --- normalize by density ---
+        # --- normalize by density (SOC-style gated density mixing) ---
         density = scatter_sum(src=edge_density, index=receiver, dim=0, dim_size=num_nodes)
+        density_magmom = scatter_sum(src=edge_density_magmom, index=receiver, dim=0, dim_size=num_nodes)
+        gate = torch.sigmoid(self.density_gate(torch.cat([density, density_magmom], dim=-1)))
+        density = gate * density + (1.0 - gate) * density_magmom
         density = density + 1.0
 
         # --- linear and skip connections ---
@@ -3632,7 +3667,7 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
     def _setup(self) -> None:
         if not hasattr(self, "cueq_config"):
             self.cueq_config = None
-        self.node_feats_down_irreps = o3.Irreps("64x0e")
+        self.node_feats_down_irreps = self.node_feats_irreps
         # First linear
         self.linear_up = Linear(
             self.node_feats_irreps,

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -253,6 +253,10 @@ class RadialEmbeddingBlock(torch.nn.Module):
         self.cutoff_fn = PolynomialCutoff(r_max=r_max, p=num_polynomial_cutoff)
         self.out_dim = num_bessel
 
+        # chho: new
+        self.num_polynomial_cutoff = num_polynomial_cutoff
+        
+
     def forward(
         self,
         edge_lengths: torch.Tensor,  # [n_edges, 1]
@@ -266,8 +270,12 @@ class RadialEmbeddingBlock(torch.nn.Module):
                 edge_lengths, node_attrs, edge_index, atomic_numbers
             )
         radial = self.bessel_fn(edge_lengths)  # [n_edges, n_basis]
-        if self.cutoff_fn.p != 0:
-            radial = radial * cutoff  # [n_edges, n_basis]
+        if not hasattr(self, "num_polynomial_cutoff"):
+            if self.cutoff_fn.p != 0:
+                radial = radial * cutoff  # [n_edges, n_basis]
+        else:
+            if self.num_polynomial_cutoff != 0:
+                radial = radial * cutoff  # [n_edges, n_basis]
         return radial
 
 

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -21,6 +21,8 @@ from mace.modules.wrapper_ops import (
 )
 from mace.tools.compile import simplify_if_compile
 from mace.tools.scatter import scatter_sum
+from .symmetric_contraction import NonSOCSymmetricContraction
+
 
 from .irreps_tools import (
     linear_out_irreps,
@@ -303,6 +305,14 @@ class EquivariantProductBasisBlock(torch.nn.Module):
                 num_elements=num_elements,
                 cueq_config=cueq_config,
             )
+        elif contraction_cls == "NonSOCSymmetricContraction":
+            self.symmetric_contractions = NonSOCSymmetricContraction(
+                irreps_in=node_feats_irreps,
+                irreps_out=target_irreps,
+                correlation=correlation,
+                num_elements=num_elements,
+                cueq_config=cueq_config,
+            )
         else:
             raise ValueError("Contraction class not supported")
         # Update linear
@@ -344,6 +354,122 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         if self.use_sc and sc is not None:
             return self.linear(node_feats) + sc
         return self.linear(node_feats)
+
+
+@compile_mode("script")
+class EquivariantProductBasisNonSOCWithSelfMagmomBlock(torch.nn.Module):
+    def __init__(
+        self,
+        node_feats_irreps: o3.Irreps,
+        target_irreps: o3.Irreps,
+        magmom_node_inv_feats_irreps: o3.Irreps,
+        magmom_node_attrs_irreps: o3.Irreps,
+        correlation: int,
+        use_sc: bool = True,
+        num_elements: Optional[int] = None,
+        cueq_config: Optional[CuEquivarianceConfig] = None,
+        contraction_cls: Optional[str] = "SymmetricContraction"
+    ) -> None:
+        super().__init__()
+
+        self.use_sc = use_sc
+        self.magmom_node_inv_feats_irreps = magmom_node_inv_feats_irreps
+        self.magmom_node_attrs_irreps = magmom_node_attrs_irreps
+        self.cueq_config = cueq_config
+        self.contraction_cls = contraction_cls
+        
+        if contraction_cls == "SymmetricContraction":
+            self.symmetric_contractions = SymmetricContractionWrapper(
+                irreps_in=node_feats_irreps,
+                irreps_out=target_irreps,
+                correlation=correlation,
+                num_elements=num_elements,
+                cueq_config=cueq_config,
+            )
+        elif contraction_cls == "NonSOCSymmetricContraction":
+            self.symmetric_contractions = NonSOCSymmetricContraction(
+                irreps_in=node_feats_irreps,
+                irreps_out=target_irreps,
+                correlation=correlation,
+                num_elements=num_elements,
+                # cueq_config=cueq_config,
+            )
+        else:
+            raise ValueError("Contraction class not supported")
+        
+        weight_irreps = o3.Irreps(f"128x0e")
+        magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
+
+        # Build the TensorProduct between node features and those scalar weights
+        irreps_mid = target_irreps
+
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [magmom_input_dim] + [64, 64, 64] + [128],
+            torch.nn.functional.silu,
+        )
+        
+        self.conv_tp = FullyConnectedTensorProduct(
+            o3.Irreps(str(target_irreps)),
+            weight_irreps,
+            irreps_mid,
+            cueq_config=self.cueq_config,
+        )
+
+        
+        # Update linear
+        self.linear = Linear(
+            self.conv_tp.irreps_out,
+            o3.Irreps(str(target_irreps)),
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=cueq_config,
+        )
+        self.linear_ori = Linear(
+            o3.Irreps(str(target_irreps)),
+            o3.Irreps(str(target_irreps)),
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=cueq_config,
+        )
+    def forward(
+        self,
+        node_feats: torch.Tensor,
+        sc: Optional[torch.Tensor],
+        node_attrs: torch.Tensor,
+        magmom_node_inv_feats: torch.Tensor,
+        magmom_node_attrs: torch.Tensor,
+    ) -> torch.Tensor:
+        use_cueq = False
+        use_cueq_mul_ir = False
+        if hasattr(self, "cueq_config"):
+            if self.cueq_config is not None:
+                if self.cueq_config.enabled and (
+                    self.cueq_config.optimize_all or self.cueq_config.optimize_symmetric
+                ):
+                    use_cueq = True
+                if self.cueq_config.layout_str == "mul_ir":
+                    use_cueq_mul_ir = True
+        if use_cueq:
+            if use_cueq_mul_ir:
+                node_feats = torch.transpose(node_feats, 1, 2)
+            index_attrs = torch.nonzero(node_attrs)[:, 1].int()
+            node_feats = self.symmetric_contractions(
+                node_feats.flatten(1),
+                index_attrs,
+            )
+        else:
+            node_feats = self.symmetric_contractions(node_feats, node_attrs)
+
+        # interaction with magnectic moment
+        tp_weights = self.conv_tp_weights(magmom_node_inv_feats)
+        
+        out = self.conv_tp(node_feats, tp_weights)
+
+        if self.use_sc and sc is not None:
+            out_message = self.linear(out) + self.linear_ori(node_feats) + sc
+        else:
+            out_message = self.linear(out) + self.linear_ori(node_feats)
+        return out_message
 
 
 @compile_mode("script")
@@ -1981,15 +2107,12 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
             internal_weights=False,
             cueq_config=self.cueq_config,
         )
-        self.reshape_mji = reshape_irreps(self.conv_tp.irreps_out)
-        self.inv_reshape_mji = inverse_reshape_irreps(self.conv_tp.irreps_out)
+        
+        self.reshape_mji = reshape_irreps(self.conv_tp.irreps_out, cueq_config=self.cueq_config)
+        #self.inv_reshape_mji = inverse_reshape_irreps(self.conv_tp.irreps_out, cueq_config=self.cueq_config)
 
         # TensorProduct in magnetic moment space
-        magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(
-            self.node_feats_irreps,
-            self.magmom_node_attrs_irreps,
-            self.target_irreps,
-        )
+        magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(self.node_feats_irreps,self.magmom_node_attrs_irreps,self.target_irreps,)
         self.magmom_conv_tp = TensorProduct(
             self.node_feats_irreps,
             self.magmom_node_attrs_irreps,
@@ -1999,8 +2122,8 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
             internal_weights=False,
             cueq_config=self.cueq_config,
         )
-        self.reshape_magmom_mji = reshape_irreps(self.magmom_conv_tp.irreps_out)
-        self.inv_reshape_magmom_mji = inverse_reshape_irreps(self.magmom_conv_tp.irreps_out)
+        #self.reshape_magmom_mji = reshape_irreps(self.magmom_conv_tp.irreps_out)
+        #self.inv_reshape_magmom_mji = inverse_reshape_irreps(self.magmom_conv_tp.irreps_out)
 
         # Convolution weights 
         # fix later
@@ -2050,7 +2173,7 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
 
         # Density normalization
         self.density_fn = nn.FullyConnectedNet(
-            [input_dim]
+            [input_dim + magmom_input_dim]
             + [
                 1,
             ],
@@ -2082,7 +2205,6 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
 
         # boardcast node feats to number of nodes
         magmom_inv_feats_j = magmom_node_inv_feats[sender]
-        
 
         edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
 
@@ -2090,7 +2212,7 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
         tp_weights = self.conv_tp_weights(edge_feats_with_magmom)
 
         # density normalization
-        edge_density = torch.tanh(self.density_fn(edge_feats) ** 2)
+        edge_density = torch.tanh(self.density_fn(edge_feats_with_magmom) ** 2)
 
         pre_mji = self.conv_tp(
             node_feats[sender], edge_attrs, tp_weights
@@ -2099,18 +2221,21 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
         
         tp_weights_magmom = self.conv_tp_weights_magmom(edge_feats_with_magmom)
         tp_weights_magmom = tp_weights_magmom.reshape(num_edges, num_k, lmax_magmom+1)
+        # this is just CP decomposition
         tp_weights_magmom = tp_weights_magmom * pre_mji[:, :num_k].unsqueeze(-1)
-        tp_weights_magmom = tp_weights_magmom.reshape(num_edges, -1)
+        tp_weights_magmom = tp_weights_magmom.reshape(num_edges, tp_weights_magmom.shape[1] * tp_weights_magmom.shape[2])
 
         magmom_mji = self.magmom_conv_tp(
             node_feats[sender], magmom_node_attrs[sender], tp_weights_magmom
         )  # [n_edges, irreps]
         
         # 
-        tp_weights = tp_weights.reshape(num_edges, num_k, -1)
+        tp_weights = tp_weights.reshape(num_edges, num_k, tp_weights.shape[1] // num_k)
+        # same here
         tp_weights = tp_weights * magmom_mji[:, :num_k].unsqueeze(-1)
-        tp_weights = tp_weights.reshape(num_edges, -1)
+        tp_weights = tp_weights.reshape(num_edges, tp_weights.shape[1] * tp_weights.shape[2])
 
+        # import pdb; pdb.set_trace();
         mji = self.conv_tp(
             node_feats[sender], edge_attrs, tp_weights
         )  # [n_edges, irreps]
@@ -2145,9 +2270,9 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
         noSO_message = self.linear(noSO_message) / (density + 1)
         noSO_message = self.skip_tp(noSO_message, node_attrs)
         # not doing density normalization for now
-        noSO_magmom_message = self.magmom_linear(noSO_magmom_message) / self.avg_num_neighbors
+        noSO_magmom_message = self.magmom_linear(noSO_magmom_message) / (density + 1)
         noSO_magmom_message = self.magmom_skip_tp(noSO_magmom_message, node_attrs)
-
+        # import pdb; pdb.set_trace();
         return (
             self.reshape(noSO_message),
             None,
@@ -2156,6 +2281,236 @@ class MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock(Magnet
             SO_message,
             None
         )  # [n_nodes, channels, (lmax + 1)**2]
+
+@compile_mode("script")
+class MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock(MagneticInteractionBlock):
+    """
+    Non-SOC interaction block that constructs A_{k k' l l' m m'} = sum_j φ_{k l m}(r_j) φ'_{k' l' m'}(m_j)
+    via pointwise (k,k') contraction (CP decomposition).
+    """
+
+    def _setup(self) -> None:
+        if not hasattr(self, "cueq_config"):
+            self.cueq_config = None
+
+        # --- 1. Linear preprocessing on node features ---
+        self.linear_up = Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+
+        # --- 2. TensorProduct for real-space (r) message ---
+        irreps_r_mid, instr_r = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp_r = TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_r_mid,
+            instructions=instr_r,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+
+        # --- 3. TensorProduct for magnetic-space (m) message ---
+        irreps_m_mid, instr_m = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.magmom_node_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp_m = TensorProduct(
+            self.node_feats_irreps,
+            self.magmom_node_attrs_irreps,
+            irreps_m_mid,
+            instructions=instr_m,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+
+        # --- 4. MLPs generating radial/magnetic weights ---
+        input_dim = self.edge_feats_irreps.num_irreps
+        magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
+        self.conv_tp_r_weights = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + self.radial_MLP + [self.conv_tp_r.weight_numel],
+            torch.nn.functional.silu,
+        )
+        self.conv_tp_m_weights = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + self.radial_MLP + [self.conv_tp_m.weight_numel],
+            torch.nn.functional.silu,
+        )
+
+        self.reshape_tp_m_mji = reshape_irreps(self.conv_tp_m.irreps_out, cueq_config=self.cueq_config)
+        self.inv_reshape_tp_m_mji = inverse_reshape_irreps(self.conv_tp_m.irreps_out, cueq_config=self.cueq_config)
+
+        self.reshape_tp_r_mji = reshape_irreps(self.conv_tp_r.irreps_out, cueq_config=self.cueq_config)
+        self.inv_reshape_tp_r_mji = inverse_reshape_irreps(self.conv_tp_r.irreps_out, cueq_config=self.cueq_config)
+
+
+        # --- 5. Linear post-processing ---
+        self.irreps_out = self.target_irreps
+        self.linear_r = Linear(
+            irreps_r_mid, self.irreps_out,
+            internal_weights=True, shared_weights=True, cueq_config=self.cueq_config,
+        )
+        self.linear_m = Linear(
+            irreps_m_mid, self.irreps_out,
+            internal_weights=True, shared_weights=True, cueq_config=self.cueq_config,
+        )
+
+        # --- 6. Selector TensorProducts (skip connections) ---
+        # self.skip_tp_r = FullyConnectedTensorProduct(
+        #     self.irreps_out, self.node_attrs_irreps, self.irreps_out, cueq_config=self.cueq_config,
+        # )
+        # self.skip_tp_m = FullyConnectedTensorProduct(
+        #     self.irreps_out, self.node_attrs_irreps, self.irreps_out, cueq_config=self.cueq_config,
+        # )
+
+        # self.linear_lr_weight_list = torch.nn.ParameterList()
+        # for mul_r, ir_r in self.conv_tp_r.irreps_out:
+        #     W = torch.nn.Parameter(torch.randn(mul_r, mul_r) / np.sqrt(mul_r))
+        #     self.linear_lr_weight_list.append(W)
+
+        # self.linear_lm_weight_list = torch.nn.ParameterList()
+        # for mul_m, ir_m in self.conv_tp_m.irreps_out:
+        #     W = torch.nn.Parameter(torch.randn(mul_m, mul_m) / np.sqrt(mul_m))
+        #     self.linear_lm_weight_list.append(W)
+
+        # In _setup, define joint weights:
+        self.linear_block_weight_list = torch.nn.ParameterList()
+        for mul_r, ir_r in self.conv_tp_r.irreps_out:
+            block_weights = []
+            for mul_m, ir_m in self.conv_tp_m.irreps_out:
+                # Joint weight for this (l, l') block
+                # Operates on the shared k dimension
+                # Assuming k is the same for both r and m (from the einsum 'bkl,bkp->bklp')
+                k_size = mul_r  # or determine from architecture
+                W = torch.nn.Parameter(torch.randn(k_size, k_size) / np.sqrt(k_size))
+                block_weights.append(W)
+            self.linear_block_weight_list.append(torch.nn.ParameterList(block_weights))
+
+
+
+        # --- 7. Density normalization ---
+        self.density_fn = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + [1],
+            torch.nn.functional.silu,
+        )
+
+        # --- 8. Reshape utility ---
+        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        # self.inv_reshape = inverse_reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+
+    # =========================================================
+    # Forward pass
+    # =========================================================
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+        magmom_node_inv_feats: torch.Tensor,
+        magmom_node_attrs: torch.Tensor,
+        couple_SO: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, None]:
+
+        sender, receiver = edge_index
+        num_edges = len(sender)
+        num_nodes = node_feats.shape[0]
+
+        # --- preprocess node features ---
+        node_feats = self.linear_up(node_feats)
+        magmom_inv_feats_j = magmom_node_inv_feats[sender]
+
+        # --- combine edge + magnetic invariants for radial weights ---
+        edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)
+
+        # --- compute TP weights ---
+        tp_r_weights = self.conv_tp_r_weights(edge_feats_with_magmom)
+        tp_m_weights = self.conv_tp_m_weights(edge_feats_with_magmom)
+
+        # --- density normalization term ---
+        edge_density = torch.tanh(self.density_fn(edge_feats_with_magmom) ** 2)
+
+        # --- compute positional and magnetic edge messages ---
+        r_msg = self.conv_tp_r(node_feats[sender], edge_attrs, tp_r_weights)  # φ_{klm}(r_j)
+        m_msg = self.conv_tp_m(node_feats[sender], magmom_node_attrs[sender], tp_m_weights)  # φ'_{k'l'm'}(m_j)
+        
+        # import pdb; pdb.set_trace();
+        r_msg = self.reshape_tp_r_mji(r_msg)
+        m_msg = self.reshape_tp_m_mji(m_msg)
+        # import pdb; pdb.set_trace();
+        # --- CP-type contraction: pointwise product over (k,k') ---
+        # both r_msg and m_msg: [n_edges, irreps_dim] (same per-edge shape)
+        A_msg = torch.einsum('bkl,bkp->bklp', r_msg, m_msg)  # elementwise CP product = A_{kk'll'mm'}(edge)
+
+        # --- aggregate to nodes (sum over j) ---
+        pooled_A = scatter_sum(src=A_msg, index=receiver, dim=0, dim_size=num_nodes)
+
+        # --- normalize by density ---
+        density = scatter_sum(src=edge_density, index=receiver, dim=0, dim_size=num_nodes)
+        density = density + 1.0
+
+        # --- linear and skip connections ---
+        # Loop over irreps blocks
+        # Create a new buffer to store the output (same shape)
+         # In forward, apply block-wise transformations:
+        pooled_A_transformed = torch.zeros_like(pooled_A)
+
+        r_dim_offsets = np.cumsum([0] + [mul * ir.dim for mul, ir in self.conv_tp_r.irreps_out])
+        m_dim_offsets = np.cumsum([0] + [mul * ir.dim for mul, ir in self.conv_tp_m.irreps_out])
+
+        for i_l, (mul_r, ir_r) in enumerate(self.conv_tp_r.irreps_out):
+            dim_r_start, dim_r_end = r_dim_offsets[i_l], r_dim_offsets[i_l + 1]
+            
+            for j_l, (mul_m, ir_m) in enumerate(self.conv_tp_m.irreps_out):
+                dim_m_start, dim_m_end = m_dim_offsets[j_l], m_dim_offsets[j_l + 1]
+                
+                # Get block-specific weight
+                W_block = self.linear_block_weight_list[i_l][j_l]  # [k, k']
+                
+                # Extract (l, l') block from pooled_A
+                A_block = pooled_A[:, :, dim_r_start:dim_r_end, dim_m_start:dim_m_end]
+                # Shape: [batch, k, dim_r, dim_m]
+                
+                # Apply transformation on k dimension
+                A_transformed = torch.einsum('bkdq,km->bmdq', A_block, W_block)
+                
+                # Store in output
+                pooled_A_transformed[:, :, dim_r_start:dim_r_end, dim_m_start:dim_m_end] = A_transformed
+
+        # Use pooled_A_transformed for subsequent operations
+        # out_A = pooled_A_transformed
+
+        # Now replace pooled_A
+        pooled_A = pooled_A_transformed / density.unsqueeze(-1).unsqueeze(-1)
+
+        # introduce skip_connection, skip for now
+        # out_A = self.skip_tp_r(self.linear_r(pooled_A) / density, node_attrs)
+
+        if couple_SO:
+            raise ValueError("SOC coupling not implemented in this non-SOC block.")
+        else:
+            SO_message = None
+
+        # --- output ---
+        return (
+            pooled_A,  # combined positional–magnetic message (A_{kk'll'mm'})
+            None,
+            None,  # pure magnetic message
+            None,
+            SO_message,
+            None,
+        )
+
 
 
 @compile_mode("script")

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -1502,7 +1502,7 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
             shared_weights=True,
             cueq_config=self.cueq_config,
         )
-        print("===done init linear===")
+        
         # TensorProduct for real space
         irreps_mid, instructions = tp_out_irreps_with_instructions(
             self.node_feats_irreps,
@@ -1518,7 +1518,7 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
             internal_weights=False,
             cueq_config=self.cueq_config,
         )
-        print("===done init conv_tp===")
+        
         # TensorProduct in magnetic moment space
         magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(
             #self.conv_tp.irreps_out,
@@ -1535,7 +1535,7 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
             internal_weights=False,
             cueq_config=self.cueq_config,
         )
-        print("===done init magmom conv_tp===")
+        
         # Convolution weights 
         input_dim = self.edge_feats_irreps.num_irreps
         magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
@@ -1628,7 +1628,168 @@ class MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock(MagneticIntera
             None,
         )  # [n_nodes, channels, (lmax + 1)**2]
 
+@compile_mode("script")
+class MagneticRealAgnosticSpinOrbitCoupledDensityWithMagmomInteractionBlock(MagneticInteractionBlock):
+    def _setup(self) -> None:
+        if not hasattr(self, "cueq_config"):
+            self.cueq_config = None
 
+        print("into MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock")
+        # First linear
+        self.linear_up = Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+        
+        # TensorProduct for real space
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+        
+        # TensorProduct in magnetic moment space
+        magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(
+            #self.conv_tp.irreps_out,
+            irreps_mid,
+            self.magmom_node_attrs_irreps,
+            self.target_irreps,
+        )
+        self.magmom_conv_tp = TensorProduct(
+            self.conv_tp.irreps_out,
+            self.magmom_node_attrs_irreps,
+            magmom_irreps_mid,
+            instructions=magmom_instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+        
+        # Convolution weights 
+        input_dim = self.edge_feats_irreps.num_irreps
+        magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + self.radial_MLP + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+        # transforming from radial l channels to magnetic l channels
+        self.conv_tp_weights_magmom = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim, ] + [self.magmom_conv_tp.weight_numel, ]
+        )
+
+        # Linear
+        self.irreps_out = self.target_irreps
+
+        self.magmom_linear = Linear(
+            self.magmom_conv_tp.irreps_out,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+        self.magmom_skip_tp = FullyConnectedTensorProduct(
+            self.irreps_out,
+            self.node_attrs_irreps,
+            self.irreps_out,
+            cueq_config=self.cueq_config,
+        )
+
+        # Density normalization
+        self.density_fn = nn.FullyConnectedNet(
+            [input_dim]
+            + [
+                1,
+            ],
+            torch.nn.functional.silu,
+        )
+
+        self.density_fn_magmom = nn.FullyConnectedNet(
+            [magmom_input_dim]
+            + [
+                1,
+            ],
+            torch.nn.functional.silu,
+        )
+        
+        self.density_gate = nn.FullyConnectedNet(
+            [2, 1],
+            torch.nn.functional.silu  # or identity
+        )
+
+        # Reshape
+        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor, # (n_edges, n_basis)
+        edge_index: torch.Tensor,
+        magmom_node_inv_feats: torch.Tensor,
+        magmom_node_attrs: torch.Tensor
+    ) -> Tuple[torch.Tensor, None]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        
+        num_nodes = node_feats.shape[0]
+        node_feats = self.linear_up(node_feats)
+        
+        # boardcast node feats to number of nodes
+        magmom_inv_feats_j = magmom_node_inv_feats[sender]
+        
+        edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
+        
+        # combined learnable radial
+        tp_weights = self.conv_tp_weights(edge_feats_with_magmom)
+
+        # density normalization
+        edge_density = torch.tanh(self.density_fn(edge_feats) ** 2)
+        edge_density_magmom = torch.tanh(self.density_fn_magmom(magmom_inv_feats_j) ** 2)
+
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        
+        tp_weights_magmom = self.conv_tp_weights_magmom(edge_feats_with_magmom)
+        
+        magmom_mji = self.magmom_conv_tp(
+            mji, magmom_node_attrs[sender], tp_weights_magmom
+        )  # [n_edges, irreps]
+        
+        density = scatter_sum(
+            src=edge_density, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, 1]
+        density_magmom = scatter_sum(
+            src=edge_density_magmom, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, 1]
+        
+        magmom_message = scatter_sum(
+            src=magmom_mji, index=receiver, dim = 0, dim_size=num_nodes,
+        )
+
+        gate = torch.sigmoid(self.density_gate(torch.cat([density, density_magmom], dim=-1)))
+        magmom_message = self.magmom_linear(magmom_message)
+        magmom_message = gate * magmom_message
+        
+        magmom_message = self.magmom_skip_tp(magmom_message, node_attrs)
+        return (
+            self.reshape(magmom_message),
+            None,
+        )  # [n_nodes, channels, (lmax + 1)**2]
+    
 @compile_mode("script")
 class MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock(MagneticInteractionBlock):
     def _setup(self) -> None:
@@ -1770,6 +1931,179 @@ class MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock(Magnetic
             None,
         )  # [n_nodes, channels, (lmax + 1)**2]
 
+
+@compile_mode("script")
+class MagneticRealAgnosticResidueSpinOrbitCoupledDensityWithMagmomInteractionBlock(MagneticInteractionBlock):
+    def _setup(self) -> None:
+        if not hasattr(self, "cueq_config"):
+            self.cueq_config = None
+
+        # First linear
+        self.linear_up = Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+
+        # TensorProduct for real space
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+
+        # TensorProduct in magnetic moment space
+        magmom_irreps_mid, magmom_instructions = tp_out_irreps_with_instructions(
+            #self.conv_tp.irreps_out,
+            irreps_mid,
+            self.magmom_node_attrs_irreps,
+            self.target_irreps,
+        )
+        self.magmom_conv_tp = TensorProduct(
+            self.conv_tp.irreps_out,
+            self.magmom_node_attrs_irreps,
+            magmom_irreps_mid,
+            instructions=magmom_instructions,
+            shared_weights=False,
+            internal_weights=False,
+            cueq_config=self.cueq_config,
+        )
+        
+        # Convolution weights 
+        input_dim = self.edge_feats_irreps.num_irreps
+        magmom_input_dim = self.magmom_node_inv_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim] + self.radial_MLP + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+        # transforming from radial l channels to magnetic l channels
+        self.conv_tp_weights_magmom = nn.FullyConnectedNet(
+            [input_dim + magmom_input_dim, ] + [self.magmom_conv_tp.weight_numel, ]
+        )
+
+        # Linear
+        self.irreps_out = self.target_irreps
+
+        self.magmom_linear = Linear(
+            self.magmom_conv_tp.irreps_out,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+            cueq_config=self.cueq_config,
+        )
+        # self.magmom_skip_tp = FullyConnectedTensorProduct(
+        #     self.irreps_out,
+        #     self.node_attrs_irreps,
+        #     self.irreps_out,
+        #     cueq_config=self.cueq_config,
+        # )
+
+        # Selector TensorProduct
+        self.skip_tp = FullyConnectedTensorProduct(
+            self.node_feats_irreps,
+            self.node_attrs_irreps,
+            self.hidden_irreps,
+            cueq_config=self.cueq_config,
+        )
+
+        # Density normalization
+        self.density_fn = nn.FullyConnectedNet(
+            [input_dim]
+            + [
+                1,
+            ],
+            torch.nn.functional.silu,
+        )
+        self.density_fn_magmom = nn.FullyConnectedNet(
+            [magmom_input_dim]
+            + [
+                1,
+            ],
+            torch.nn.functional.silu,
+        )
+
+        self.density_gate = nn.FullyConnectedNet(
+            [2, 1],
+            torch.nn.functional.silu  # or identity
+        )
+
+        
+        # Reshape
+        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor, # (n_edges, n_basis)
+        edge_index: torch.Tensor,
+        magmom_node_inv_feats: torch.Tensor,
+        magmom_node_attrs: torch.Tensor
+    ) -> Tuple[torch.Tensor, None]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        
+        num_nodes = node_feats.shape[0]
+
+        # residue connection
+        sc = self.skip_tp(node_feats, node_attrs)
+
+        #
+        node_feats = self.linear_up(node_feats)
+        
+        # boardcast node feats to number of nodes
+        magmom_inv_feats_j = magmom_node_inv_feats[sender]
+
+        edge_feats_with_magmom = torch.cat([edge_feats, magmom_inv_feats_j], dim=-1)        
+        
+        # combined learnable radial
+        tp_weights = self.conv_tp_weights(edge_feats_with_magmom)
+
+        # density normalization
+        edge_density = torch.tanh(self.density_fn(edge_feats) ** 2)
+        edge_density_magmom = torch.tanh(self.density_fn_magmom(magmom_inv_feats_j) ** 2)
+
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        
+        tp_weights_magmom = self.conv_tp_weights_magmom(edge_feats_with_magmom)
+        
+        magmom_mji = self.magmom_conv_tp(
+            mji, magmom_node_attrs[sender], tp_weights_magmom
+        )  # [n_edges, irreps]
+        
+        density = scatter_sum(
+            src=edge_density, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, 1]
+        density_magmom = scatter_sum(
+            src=edge_density_magmom, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, 1]
+        
+        magmom_message = scatter_sum(
+            src=magmom_mji, index=receiver, dim=0, dim_size=num_nodes,
+        )
+
+        gate = torch.sigmoid(self.density_gate(torch.cat([density, density_magmom], dim=-1)))
+        magmom_message = gate * self.magmom_linear(magmom_message)
+
+        return (
+            self.reshape(magmom_message),
+            sc,
+        )  # [n_nodes, channels, (lmax + 1)**2]
 
 @compile_mode("script")
 class MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock(MagneticInteractionBlock):
@@ -1924,6 +2258,7 @@ class MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock(Magneti
             self.reshape(magmom_message),
             sc,
         )  # [n_nodes, channels, (lmax + 1)**2]
+
 
 @compile_mode("script")
 class MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock(MagneticInteractionBlock):

--- a/mace/modules/irreps_tools.py
+++ b/mace/modules/irreps_tools.py
@@ -100,7 +100,8 @@ class reshape_irreps(torch.nn.Module):
         self, irreps: o3.Irreps, cueq_config: Optional[CuEquivarianceConfig] = None
     ) -> None:
         super().__init__()
-        self.irreps = o3.Irreps(irreps)
+        
+        self.irreps = o3.Irreps(str(irreps))
         self.cueq_config = cueq_config
         self.dims = []
         self.muls = []
@@ -137,27 +138,75 @@ class reshape_irreps(torch.nn.Module):
                 return torch.cat(out, dim=-1)
         return torch.cat(out, dim=-1)
 
+# @compile_mode("script")
+# class inverse_reshape_irreps(torch.nn.Module):
+#     def __init__(self, irreps: o3.Irreps) -> None:
+#         super().__init__()
+#         self.irreps = o3.Irreps(irreps)
+#         self.dims = []
+#         self.muls = []
+#         for mul, ir in self.irreps:
+#             d = ir.dim
+#             self.dims.append(d)
+#             self.muls.append(mul)
+
+#     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+#         out = []
+#         dsum = 0
+#         for mul, d in zip(self.muls, self.dims):
+#             field = tensor[:,:,dsum:dsum+d]  # [batch, mul, repr]
+#             field = field.reshape(tensor.shape[0], -1)  # Flatten [batch, mul * repr]
+#             dsum += d
+#             out.append(field)
+#         return torch.cat(out, dim=-1)
+
 @compile_mode("script")
 class inverse_reshape_irreps(torch.nn.Module):
-    def __init__(self, irreps: o3.Irreps) -> None:
+    def __init__(
+        self,
+        irreps: o3.Irreps,
+        cueq_config: Optional[CuEquivarianceConfig] = None,
+    ) -> None:
         super().__init__()
-        self.irreps = o3.Irreps(irreps)
+        self.irreps = o3.Irreps(str(irreps))
+        self.cueq_config = cueq_config
         self.dims = []
         self.muls = []
         for mul, ir in self.irreps:
-            d = ir.dim
-            self.dims.append(d)
+            self.dims.append(ir.dim)
             self.muls.append(mul)
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Inverse of reshape_irreps:
+        - If layout_str == "mul_ir": input is [batch, mul, sum_d], slice along last dim.
+        - Else:                       input is [batch, sum_d, mul], slice along second-to-last dim.
+        Returns [batch, total_dim].
+        """
+        batch = tensor.shape[0]
         out = []
         dsum = 0
+
+        if hasattr(self, "cueq_config") and self.cueq_config is not None:
+            mul_ir = (self.cueq_config.layout_str == "mul_ir")
+        else:
+            # Default matches reshape_irreps default (mul, d) then concat along last dim
+            mul_ir = True
+
         for mul, d in zip(self.muls, self.dims):
-            field = tensor[:,:,dsum:dsum+d]  # [batch, mul, repr]
-            field = field.reshape(tensor.shape[0], -1)  # Flatten [batch, mul * repr]
+            if mul_ir:
+                # tensor: [batch, mul, sum_d]  -> slice along last dim
+                field = tensor[:, :, dsum:dsum + d]           # [B, mul, d]
+                field = field.reshape(batch, -1)              # [B, mul*d]
+            else:
+                # tensor: [batch, sum_d, mul] -> slice along second-to-last dim
+                field = tensor[:, dsum:dsum + d, :]           # [B, d, mul]
+                field = field.reshape(batch, -1)              # [B, d*mul]
             dsum += d
             out.append(field)
-        return torch.cat(out, dim=-1)
+        import pdb; pdb.set_trace();
+        return torch.cat(out, dim=-1)                         # [B, total_dim]
+
 
 def mask_head(x: torch.Tensor, head: torch.Tensor, num_heads: int) -> torch.Tensor:
     mask = torch.zeros(x.shape[0], x.shape[1] // num_heads, num_heads, device=x.device)

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -446,12 +446,15 @@ class UniversalLoss(torch.nn.Module):
                 reduction="mean",
                 delta=self.huber_delta,
             )
-            loss_magforces = torch.nn.functional.huber_loss(
-                configs_magforces_weight * ref["magforces"],
-                configs_magforces_weight * pred["magforces"],
-                reduction="mean",
-                delta=self.huber_delta,
-            )
+            if "magforces" in pred.keys():
+                loss_magforces = torch.nn.functional.huber_loss(
+                    configs_magforces_weight * ref["magforces"],
+                    configs_magforces_weight * pred["magforces"],
+                    reduction="mean",
+                    delta=self.huber_delta,
+                )
+            else:
+                loss_magforces = 0
         return (
             self.energy_weight * loss_energy
             + self.forces_weight * loss_forces
@@ -463,6 +466,7 @@ class UniversalLoss(torch.nn.Module):
         return (
             f"{self.__class__.__name__}(energy_weight={self.energy_weight:.3f}, "
             f"forces_weight={self.forces_weight:.3f}, stress_weight={self.stress_weight:.3f})"
+            f"magforces={self.magforces_weight:.3f}"
         )
 
 

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -369,7 +369,7 @@ class WeightedHuberEnergyForcesStressLoss(torch.nn.Module):
 
 class UniversalLoss(torch.nn.Module):
     def __init__(
-        self, energy_weight=1.0, forces_weight=1.0, stress_weight=1.0, huber_delta=0.01
+        self, energy_weight=1.0, forces_weight=1.0, stress_weight=1.0, magmom_weight=1.0, huber_delta=0.01
     ) -> None:
         super().__init__()
         self.huber_delta = huber_delta
@@ -384,6 +384,10 @@ class UniversalLoss(torch.nn.Module):
         self.register_buffer(
             "stress_weight",
             torch.tensor(stress_weight, dtype=torch.get_default_dtype()),
+        )
+        self.register_buffer(
+            "magmom_weight",
+            torch.tensor(magmom_weight, dtype=torch.get_default_dtype()),
         )
 
     def forward(

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -369,7 +369,7 @@ class WeightedHuberEnergyForcesStressLoss(torch.nn.Module):
 
 class UniversalLoss(torch.nn.Module):
     def __init__(
-        self, energy_weight=1.0, forces_weight=1.0, stress_weight=1.0, magmom_weight=1.0, huber_delta=0.01
+        self, energy_weight=1.0, forces_weight=1.0, stress_weight=1.0, magmom_weight=1.0, magforces_weight=1.0, huber_delta=0.01
     ) -> None:
         super().__init__()
         self.huber_delta = huber_delta
@@ -391,7 +391,7 @@ class UniversalLoss(torch.nn.Module):
         )
         self.register_buffer(
             "magforces_weight",
-            torch.tensor(magmom_weight, dtype=torch.get_default_dtype()),
+            torch.tensor(magforces_weight, dtype=torch.get_default_dtype()),
         )
 
     def forward(

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -446,7 +446,7 @@ class UniversalLoss(torch.nn.Module):
                 reduction="mean",
                 delta=self.huber_delta,
             )
-            if "magforces" in pred.keys():
+            if "magforces" in pred.keys() and (pred["magforces"] is not None and ref["magforces"] is not None):
                 loss_magforces = torch.nn.functional.huber_loss(
                     configs_magforces_weight * ref["magforces"],
                     configs_magforces_weight * pred["magforces"],

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -401,14 +401,15 @@ class UniversalLoss(torch.nn.Module):
         self, ref: Batch, pred: TensorDict, ddp: Optional[bool] = None
     ) -> torch.Tensor:
         num_atoms = ref.ptr[1:] - ref.ptr[:-1]
-        configs_stress_weight = ref.stress_weight.view(-1, 1, 1)
-        configs_energy_weight = ref.energy_weight
+        configs_stress_weight = (ref.stress_weight * ref.weight).view(-1, 1, 1)
+        configs_energy_weight = ref.energy_weight * ref.weight
         configs_forces_weight = torch.repeat_interleave(
-            ref.forces_weight, ref.ptr[1:] - ref.ptr[:-1]
+            ref.forces_weight * ref.weight, ref.ptr[1:] - ref.ptr[:-1]
         ).unsqueeze(-1)
         configs_magforces_weight = torch.repeat_interleave(
-            ref.magforces_weight, ref.ptr[1:] - ref.ptr[:-1]
+            ref.magforces_weight * ref.weight, ref.ptr[1:] - ref.ptr[:-1]
         ).unsqueeze(-1)
+
         if ddp:
             loss_energy = torch.nn.functional.huber_loss(
                 configs_energy_weight * ref["energy"] / num_atoms,
@@ -589,4 +590,44 @@ class WeightedEnergyForcesL1L2Loss(torch.nn.Module):
         return (
             f"{self.__class__.__name__}(energy_weight={self.energy_weight:.3f}, "
             f"forces_weight={self.forces_weight:.3f})"
+        )
+
+class EvenSpline1BodyLoss(torch.nn.Module):
+    def __init__(self, lambda_smooth=3e-1,) -> None:
+        super().__init__()
+        self.register_buffer(
+            "lambda_smooth",
+            torch.tensor(lambda_smooth, dtype=torch.get_default_dtype()),
+        )
+
+    def curvature_penalty(self, y):
+        # second finite difference ~ f''(u)
+        d2 = y[:-2] - 2*y[1:-1] + y[2:]
+        return torch.mean(d2**2)
+    
+    def forward(
+        self, ref: Batch, pred: TensorDict, ddp: Optional[bool] = None
+    ) -> torch.Tensor:
+        # import pdb; pdb.set_trace();
+        data_loss = torch.mean((ref['energy'] - pred['energy'])**2)
+        
+        # --- curvature penalty grouped by element ---
+        smooth_losses = []
+        energy = pred["energy"]                 # [N]
+        node_attrs = ref.node_attrs              # [N, n_elem]
+        for elem_idx in range(node_attrs.shape[1]):
+            mask = node_attrs[:, elem_idx].bool()
+            y_elem = energy[mask]
+            smooth_losses.append(self.curvature_penalty(y_elem))
+
+        if smooth_losses:
+            smooth_loss = torch.stack(smooth_losses).mean()
+        else:
+            smooth_loss = energy.new_tensor(0.0)
+
+        return data_loss + self.lambda_smooth * smooth_loss
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(lambda_smooth={self.lambda_smooth})"
         )

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -608,7 +608,6 @@ class EvenSpline1BodyLoss(torch.nn.Module):
     def forward(
         self, ref: Batch, pred: TensorDict, ddp: Optional[bool] = None
     ) -> torch.Tensor:
-        # import pdb; pdb.set_trace();
         data_loss = torch.mean((ref['energy'] - pred['energy'])**2)
         
         # --- curvature penalty grouped by element ---

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -354,6 +354,9 @@ class WeightedHuberEnergyForcesStressLoss(torch.nn.Module):
             loss_stress = torch.nn.functional.huber_loss(
                 ref["stress"], pred["stress"], reduction="mean", delta=self.huber_delta
             )
+        print(loss_energy)
+        print(loss_forces)
+        print(loss_stress)
         return (
             self.energy_weight * loss_energy
             + self.forces_weight * loss_forces
@@ -453,6 +456,7 @@ class UniversalLoss(torch.nn.Module):
                     reduction="mean",
                     delta=self.huber_delta,
                 )
+                print("loss_magforces: ", loss_magforces)
             else:
                 loss_magforces = 0
         return (

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -3587,7 +3587,7 @@ class EnergyDipolesMACE(torch.nn.Module):
 class MagneticSCFMACE(torch.nn.Module):
     def __init__(self, model, n_scf_step=10, scf_tol=1e-5, scf_logging=False, scf_step_size=1.0, use_scf = True):
         super().__init__()
-        self.magmom_mace = model
+        self.magmom_mace = model # original magnetic mace
         self.n_scf_step = n_scf_step
         self.scf_tol = scf_tol
         self.cache_magmom = None
@@ -3625,7 +3625,8 @@ class MagneticSCFMACE(torch.nn.Module):
 
         # === Define optimizer ===
         if self.use_scf:
-            optimizer = torch.optim.LBFGS([magmom], max_iter=self.n_scf_step, tolerance_grad=self.scf_tol, line_search_fn="strong_wolfe", lr=self.scf_step_size)
+            optimizer = torch.optim.LBFGS([magmom], max_iter=self.n_scf_step, tolerance_grad=self.scf_tol, \
+                                          line_search_fn="strong_wolfe", lr=self.scf_step_size)
 
             def closure():
                 optimizer.zero_grad()

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -1654,14 +1654,15 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE(
         element_dependent_scaling = self.m_max[torch.argmax(data["node_attrs"], dim=1)].unsqueeze(-1)
         element_dependent_scaling.requires_grad_(True)
         element_dependent_scaling.retain_grad()
-        
+
+        # compute transformation for magenetic moments
         magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling) ** 2
-        # magmom_vectors = data["magmom"] / (magmom_lenghts + 1e-9)
         
-        # Compute the spherical harmonics from the normalized vectors
+        # Compute the solid harmonics
         magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
 
-        #
+        # compute magnetic radial embedding (chebyshev polynomial)
+        # on transformed coordinate
         magmom_node_feats = self.mag_radial_embedding(magmom_lenghts_trans) # (n_atoms, n_basis)
         
         # Interactions

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -737,7 +737,9 @@ class MagneticScaleShiftMACE(MagneticMACE):
 
         #print("position is_leaf before forward:", data["positions"].is_leaf)
         #print("magmom is_leaf before forward:", data["magmom"].is_leaf)
-
+        #print("======")
+        #print(data.keys())
+        #print("======")
         num_graphs = data["ptr"].numel() - 1
         num_atoms_arange = torch.arange(data["positions"].shape[0])
         node_heads = (
@@ -866,7 +868,7 @@ class MagneticScaleShiftMACE(MagneticMACE):
         # Add E_0 and (scaled) interaction energy
         total_energy = e0 + inter_e
         node_energy = node_e0 + node_inter_es
-        forces, virials, stress, hessian, mag_forces = get_outputs(
+        forces, virials, stress, hessian, magforces = get_outputs(
             energy=inter_e,
             positions=data["positions"],
             displacement=displacement,
@@ -884,7 +886,7 @@ class MagneticScaleShiftMACE(MagneticMACE):
             "node_energy": node_energy,
             "interaction_energy": inter_e,
             "forces": forces,
-            "mag_forces": mag_forces,
+            "magforces": magforces,
             "virials": virials,
             "stress": stress,
             "hessian": hessian,

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -455,7 +455,7 @@ class ScaleShiftMACE(MACE):
         # Add E_0 and (scaled) interaction energy
         total_energy = e0 + inter_e
         node_energy = node_e0 + node_inter_es
-        forces, virials, stress, hessian = get_outputs(
+        forces, virials, stress, hessian, _ = get_outputs(
             energy=inter_e,
             positions=data["positions"],
             displacement=displacement,

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -646,7 +646,7 @@ class MagneticMACE(torch.nn.Module):
                 avg_num_neighbors=avg_num_neighbors,
                 radial_MLP=radial_MLP,
                 cueq_config=cueq_config,
-                magmom_node_inv_feats_irreps=o3.Irreps(f"{self.mag_radial_embedding.num_basis}x0e"),
+                magmom_node_inv_feats_irreps=hidden_irreps, #o3.Irreps(f"{self.mag_radial_embedding.num_basis}x0e"),
                 magmom_node_attrs_irreps=magmom_sh_irreps
             )
             self.interactions.append(inter)
@@ -882,7 +882,6 @@ class MagneticScaleShiftMACE(MagneticMACE):
             "displacement": displacement,
             "node_feats": node_feats_out,
         }
-        #print("total energy: ", total_energy)
         return output
 
 class BOTNet(torch.nn.Module):

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -48,6 +48,8 @@ class MACE(torch.nn.Module):
         max_ell: int,
         interaction_cls: Type[InteractionBlock],
         interaction_cls_first: Type[InteractionBlock],
+        contraction_cls: str,
+        contraction_cls_first: str,
         num_interactions: int,
         num_elements: int,
         hidden_irreps: o3.Irreps,
@@ -136,6 +138,7 @@ class MACE(torch.nn.Module):
             num_elements=num_elements,
             use_sc=use_sc_first,
             cueq_config=cueq_config,
+            contraction_cls=contraction_cls_first
         )
         self.products = torch.nn.ModuleList([prod])
 
@@ -172,6 +175,7 @@ class MACE(torch.nn.Module):
                 num_elements=num_elements,
                 use_sc=True,
                 cueq_config=cueq_config,
+                contraction_cls=contraction_cls
             )
             self.products.append(prod)
             if i == num_interactions - 2:
@@ -465,6 +469,148 @@ class ScaleShiftMACE(MACE):
 
         return output
 
+@compile_mode("script")
+class MagneticScaleShiftMACE(MACE):
+    def __init__(
+        self,
+        atomic_inter_scale: float,
+        atomic_inter_shift: float,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.scale_shift = ScaleShiftBlock(
+            scale=atomic_inter_scale, shift=atomic_inter_shift
+        )
+
+    def forward(
+        self,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
+        compute_force: bool = True,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_hessian: bool = False,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # Setup
+        data["positions"].requires_grad_(True)
+        data["node_attrs"].requires_grad_(True)
+
+        print('======')
+        print(data['magmom'])
+        print('======')
+        num_graphs = data["ptr"].numel() - 1
+        num_atoms_arange = torch.arange(data["positions"].shape[0])
+        node_heads = (
+            data["head"][data["batch"]]
+            if "head" in data
+            else torch.zeros_like(data["batch"])
+        )
+        displacement = torch.zeros(
+            (num_graphs, 3, 3),
+            dtype=data["positions"].dtype,
+            device=data["positions"].device,
+        )
+        if compute_virials or compute_stress or compute_displacement:
+            (
+                data["positions"],
+                data["shifts"],
+                displacement,
+            ) = get_symmetric_displacement(
+                positions=data["positions"],
+                unit_shifts=data["unit_shifts"],
+                cell=data["cell"],
+                edge_index=data["edge_index"],
+                num_graphs=num_graphs,
+                batch=data["batch"],
+            )
+
+        # Atomic energies
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])[
+            num_atoms_arange, node_heads
+        ]
+        e0 = scatter_sum(
+            src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
+        )  # [n_graphs, num_heads]
+
+        # Embeddings
+        node_feats = self.node_embedding(data["node_attrs"])
+        vectors, lengths = get_edge_vectors_and_lengths(
+            positions=data["positions"],
+            edge_index=data["edge_index"],
+            shifts=data["shifts"],
+        )
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+        if hasattr(self, "pair_repulsion"):
+            pair_node_energy = self.pair_repulsion_fn(
+                lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+            )
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+        # Interactions
+        node_es_list = [pair_node_energy]
+        node_feats_list = []
+        for interaction, product, readout in zip(
+            self.interactions, self.products, self.readouts
+        ):
+            node_feats, sc = interaction(
+                node_attrs=data["node_attrs"],
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+            )
+            node_feats = product(
+                node_feats=node_feats, sc=sc, node_attrs=data["node_attrs"]
+            )
+            node_feats_list.append(node_feats)
+            node_es_list.append(
+                readout(node_feats, node_heads)[num_atoms_arange, node_heads]
+            )  # {[n_nodes, ], }
+
+        # Concatenate node features
+        node_feats_out = torch.cat(node_feats_list, dim=-1)
+        # Sum over interactions
+        node_inter_es = torch.sum(
+            torch.stack(node_es_list, dim=0), dim=0
+        )  # [n_nodes, ]
+        node_inter_es = self.scale_shift(node_inter_es, node_heads)
+
+        # Sum over nodes in graph
+        inter_e = scatter_sum(
+            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+
+        # Add E_0 and (scaled) interaction energy
+        total_energy = e0 + inter_e
+        node_energy = node_e0 + node_inter_es
+        forces, virials, stress, hessian = get_outputs(
+            energy=inter_e,
+            positions=data["positions"],
+            displacement=displacement,
+            cell=data["cell"],
+            training=training,
+            compute_force=compute_force,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_hessian=compute_hessian,
+        )
+        output = {
+            "energy": total_energy,
+            "node_energy": node_energy,
+            "interaction_energy": inter_e,
+            "forces": forces,
+            "virials": virials,
+            "stress": stress,
+            "hessian": hessian,
+            "displacement": displacement,
+            "node_feats": node_feats_out,
+        }
+
+        return output
 
 class BOTNet(torch.nn.Module):
     def __init__(

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -986,7 +986,7 @@ class SHModule(torch.nn.Module):
         sh = self.SH(torch.index_select(
                 xyz, 1, torch.tensor([2, 0, 1], dtype=torch.long,device=xyz.device)
             ))
-        return sh # * self.scaling
+        return sh
 
 @compile_mode("script")
 class MagneticSolidHarmonicsScaleShiftMACE(MagneticMACE):

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -1361,7 +1361,7 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(Magneti
     ):
         super().__init__(**kwargs)
         self.scale_shift = ScaleShiftBlock(
-            scale=atomic_inter_scale, shift=atomic_inter_shift
+            scale=atomic_inter_scale, shift=0.0
         )
 
         # modify spherical to solid harmonics for magnetic moment

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -654,7 +654,7 @@ class MagneticMACE(torch.nn.Module):
                 if "OneBody" not in self.__class__.__name__:
                     prod_block_cls = EquivariantProductBasisWithSelfMagmomBlock
                 else:
-                    if "Readout" in self.__class__.__name__ or "Ginzburg" in self.__class__.__name__:
+                    if "Readout" in self.__class__.__name__ or "Ginzburg" in self.__class__.__name__ or "EvenSpline" in self.__class__.__name__:
                         prod_block_cls = EquivariantProductBasisWithSelfMagmomBlock
                     else:
                         prod_block_cls = EquivariantProductBasisWithOneBodySelfMagmomBlock
@@ -1589,6 +1589,191 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(Magneti
         }
         return output
 
+
+
+@compile_mode("script")
+class MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomFixingScaleShiftMACE(MagneticMACE):
+    def __init__(
+        self,
+        atomic_inter_scale: float,
+        atomic_inter_shift: float,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.scale_shift = ScaleShiftBlock(
+            scale=atomic_inter_scale, shift=0.0
+        )
+
+        # modify spherical to solid harmonics for magnetic moment
+        self.mag_solid_harmoics = SHModule(self.mag_spherical_harmonics._lmax)
+
+        self.mag_spherical_harmonics = None
+        self.magmom_readouts = None
+        self.magmom_products = None
+        #self.products = new_products
+
+    def forward(
+        self,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
+        compute_force: bool = True,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_hessian: bool = False,
+        compute_magforces: bool = True,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # Setup
+        data["positions"].requires_grad_(True)
+        data["node_attrs"].requires_grad_(True)
+        data["magmom"].requires_grad_(True)
+        
+        num_graphs = data["ptr"].numel() - 1
+        num_atoms_arange = torch.arange(data["positions"].shape[0])
+        node_heads = (
+            data["head"][data["batch"]]
+            if "head" in data
+            else torch.zeros_like(data["batch"])
+        )
+        displacement = torch.zeros(
+            (num_graphs, 3, 3),
+            dtype=data["positions"].dtype,
+            device=data["positions"].device,
+        )
+        if compute_virials or compute_stress or compute_displacement:
+            (
+                data["positions"],
+                data["shifts"],
+                displacement,
+            ) = get_symmetric_displacement(
+                positions=data["positions"],
+                unit_shifts=data["unit_shifts"],
+                cell=data["cell"],
+                edge_index=data["edge_index"],
+                num_graphs=num_graphs,
+                batch=data["batch"],
+            )
+
+        # Atomic energies
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])[
+            num_atoms_arange, node_heads
+        ]
+        e0 = scatter_sum(
+            src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
+        )  # [n_graphs, num_heads]
+
+        # node embedding on species
+        node_feats = self.node_embedding(data["node_attrs"])
+
+        # prepare the Rnl and Ylm
+        vectors, lengths = get_edge_vectors_and_lengths(
+            positions=data["positions"],
+            edge_index=data["edge_index"],
+            shifts=data["shifts"],
+        )
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+        if hasattr(self, "pair_repulsion"):
+            pair_node_energy = self.pair_repulsion_fn(
+                lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+            )
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+
+        # --- magnetic stuffs ---
+        
+        magmom_lenghts = torch.norm(data["magmom"], dim=-1, keepdim=True)
+        element_dependent_scaling = self.m_max[torch.argmax(data["node_attrs"], dim=1)].unsqueeze(-1)
+        element_dependent_scaling.requires_grad_(True)
+        element_dependent_scaling.retain_grad()
+        
+        magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling)
+        # magmom_vectors = data["magmom"] / (magmom_lenghts + 1e-9)
+        
+        # Compute the spherical harmonics from the normalized vectors
+        magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
+
+        #
+        magmom_node_feats = self.mag_radial_embedding(magmom_lenghts_trans) # (n_atoms, n_basis)
+        
+        # Interactions
+        node_es_list = [pair_node_energy]
+        node_feats_list = []
+        
+
+        # one_body_magmom_energy = onebody_magmom_contri[num_atoms_arange, node_heads]
+
+        for interaction, product, readout in zip(
+            self.interactions, self.products, self.readouts
+        ):
+            node_feats, sc = interaction(
+                node_attrs=data["node_attrs"],
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs
+            )
+          
+            node_feats = product(
+                node_feats=node_feats, sc=sc,node_attrs=data["node_attrs"], 
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs
+            )
+            
+            node_feats_list.append(node_feats)
+            node_es_list.append(
+                readout(node_feats, node_heads)[num_atoms_arange, node_heads]
+            )  # {[n_nodes, ], }
+
+
+        # Concatenate node features
+        node_feats_out = torch.cat(node_feats_list, dim=-1) 
+
+        # Sum over interactions
+        node_inter_es = torch.sum(
+            torch.stack(node_es_list, dim=0), dim=0
+        )  # [n_nodes, ]
+        node_inter_es = self.scale_shift(node_inter_es, node_heads)
+
+        # Sum over nodes in graph
+        inter_e = scatter_sum(
+            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+        
+        # Add E_0 and (scaled) interaction energy
+        total_energy = e0 + inter_e
+        node_energy = node_e0 + node_inter_es
+        forces, virials, stress, hessian, magforces = get_outputs(
+            energy=inter_e,
+            positions=data["positions"],
+            displacement=displacement,
+            cell=data["cell"],
+            magmoms=data["magmom"],
+            training=training,
+            compute_force=compute_force,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_hessian=compute_hessian,
+            compute_magforces=compute_magforces,
+        )
+        output = {
+            "energy": total_energy,
+            "node_energy": node_energy,
+            "interaction_energy": inter_e,
+            "forces": forces,
+            "magforces": magforces,
+            "virials": virials,
+            "stress": stress,
+            "hessian": hessian,
+            "displacement": displacement,
+            "node_feats": node_feats_out,
+        }
+        return output
+
 @compile_mode("script")
 class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE(MagneticMACE):
     def __init__(
@@ -2297,6 +2482,587 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfM
         # one body contribution radials, this is with constant shift so that it can be fitted
         magmom_one_body_radials = self.one_body_cheb_basis_with_const(
             magmom_lenghts_trans
+        )
+        
+        # Interactions
+        node_es_list = [pair_node_energy]
+        node_feats_list = []
+        magmom_node_feats_list = []
+        for (idx, (interaction, product, readout)) in enumerate(zip(
+            self.interactions, self.products, self.readouts
+        )):
+            node_feats, sc = interaction(
+                node_attrs=data["node_attrs"],
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs
+            )
+          
+            node_feats = product(
+                node_feats=node_feats, sc=sc,node_attrs=data["node_attrs"], 
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs,
+            )
+            
+            node_feats_list.append(node_feats)
+            if idx == (len(self.readouts) - 1):    
+                # linear (natom, num_basis) -> (natom, 1)
+                # remove certain constant to make it matches with E0, 
+                # self.one_body_magmom_const_correction is computed outside after pre-training
+                # Select the correct coefficient row for each atom via einsum
+                selected_coeffs = torch.einsum(
+                    "ns,sbh->nbh", data["node_attrs"], self.onebody_magmombasis_coeffs
+                )
+                #
+                one_body_correction = torch.einsum(
+                    'ns,sh->nh', data["node_attrs"], self.one_body_magmom_const_correction
+                )
+                # Compute dot product over nbasis → (n_nodes, num_heads)
+                onebody_magmom_contri = (magmom_one_body_radials.unsqueeze(-1) * selected_coeffs).sum(dim=1)
+
+                # apply correction so that the zero matches E0 exactly
+                onebody_magmom_contri -= one_body_correction
+
+                # Gather energy per atom + one-body magmom contribution for each head
+                node_es_list.append(
+                    readout(node_feats, node_heads)[num_atoms_arange, node_heads] +
+                    onebody_magmom_contri[num_atoms_arange, node_heads]
+                )
+            else:
+                node_es_list.append(
+                    readout(node_feats, node_heads)[num_atoms_arange, node_heads]
+                )  # {[n_nodes, ], }
+
+
+        # Concatenate node features
+        node_feats_out = torch.cat(node_feats_list, dim=-1) 
+
+        # Sum over interactions
+        node_inter_es = torch.sum(
+            torch.stack(node_es_list, dim=0), dim=0
+        )  # [n_nodes, ]
+        node_inter_es = self.scale_shift(node_inter_es, node_heads)
+
+        # Sum over nodes in graph
+        inter_e = scatter_sum(
+            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+        
+        # Add E_0 and (scaled) interaction energy
+        total_energy = e0 + inter_e
+        node_energy = node_e0 + node_inter_es
+        forces, virials, stress, hessian, magforces = get_outputs(
+            energy=inter_e,
+            positions=data["positions"],
+            displacement=displacement,
+            cell=data["cell"],
+            magmoms=data["magmom"],
+            training=training,
+            compute_force=compute_force,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_hessian=compute_hessian,
+            compute_magforces=compute_magforces,
+        )
+        output = {
+            "energy": total_energy,
+            "node_energy": node_energy,
+            "interaction_energy": inter_e,
+            "forces": forces,
+            "magforces": magforces,
+            "virials": virials,
+            "stress": stress,
+            "hessian": hessian,
+            "displacement": displacement,
+            "node_feats": node_feats_out,
+        }
+        return output
+
+def natural_cubic_spline_coeffs(x, y):
+    x = x.contiguous()
+    y = y.contiguous()
+    N = x.numel()
+
+    h = x[1:] - x[:-1]
+
+    A = torch.zeros((N, N), device=x.device, dtype=x.dtype)
+    rhs = torch.zeros((N,), device=x.device, dtype=x.dtype)
+
+    A[0, 0] = 1.0
+    A[-1, -1] = 1.0
+
+    for i in range(1, N - 1):
+        A[i, i - 1] = h[i - 1]
+        A[i, i] = 2.0 * (h[i - 1] + h[i])
+        A[i, i + 1] = h[i]
+        rhs[i] = 3.0 * (
+            (y[i + 1] - y[i]) / h[i]
+            - (y[i] - y[i - 1]) / h[i - 1]
+        )
+
+    c_full = torch.linalg.solve(A, rhs)
+
+    a = y[:-1]
+    b = (y[1:] - y[:-1]) / h - h * (2.0 * c_full[:-1] + c_full[1:]) / 3.0
+    c = c_full[:-1]
+    d = (c_full[1:] - c_full[:-1]) / (3.0 * h)
+
+    return a, b, c, d
+
+
+def cubic_spline_eval(xq, x, coeffs):
+    a, b, c, d = coeffs
+    xq = torch.clamp(xq, x[0], x[-1])
+    idx = torch.searchsorted(x[1:], xq)
+    dx = xq - x[idx]
+    return a[idx] + b[idx]*dx + c[idx]*dx**2 + d[idx]*dx**3
+
+
+# ============================================================
+# Even spline model: E(m) = f(m^2)
+# ============================================================
+class EvenSpline1Body(torch.nn.Module):
+    """
+    Returns per-site energies E_i of shape (N,)
+    """
+
+    def __init__(self, m_max, n_knots=40):
+        super().__init__()
+
+        self.n_species = len(m_max)
+        self.n_knots = n_knots
+
+        self.u_knots = torch.nn.ParameterList([
+            torch.nn.Parameter(
+                torch.linspace(0.0, float(m)**2, n_knots),
+                requires_grad=False
+            )
+            for m in m_max
+        ])
+
+        self.y = torch.nn.ParameterList([
+            torch.nn.Parameter(torch.zeros(n_knots))
+            for _ in range(self.n_species)
+        ])
+
+    def forward(self, m, node_attrs):
+        """
+        m          : (N,)
+        node_attrs : (N, n_species) one-hot
+        returns    : site_energy (N,)
+        """
+        m = m.view(-1)
+        u = m * m
+
+        N = m.shape[0]
+        site_energy = torch.zeros(N, device=m.device)
+
+        active_species = torch.nonzero(
+            node_attrs.sum(dim=0), as_tuple=False
+        ).view(-1)
+
+        for s in active_species.tolist():
+            coeffs = natural_cubic_spline_coeffs(
+                self.u_knots[s], self.y[s]
+            )
+            Es = cubic_spline_eval(u, self.u_knots[s], coeffs)
+            site_energy += node_attrs[:, s] * Es
+
+        return site_energy
+
+class EvenMagSaturationBarrier(torch.nn.Module):
+    def __init__(self, m_max, E1, E2, prefactor, lambda_sat=0.05, eps=1e-8, dtype=None):
+        super().__init__()
+        if dtype is None:
+            dtype = torch.get_default_dtype()
+
+        m_max = torch.as_tensor(m_max, dtype=dtype)
+        E1 = torch.as_tensor(E1, dtype=dtype)
+        E2 = torch.as_tensor(E2, dtype=dtype)
+
+        assert m_max.ndim == 1
+        assert E1.shape == m_max.shape
+        assert E2.shape == m_max.shape
+
+        self.n_species = m_max.numel()
+
+        self.register_buffer("m_max", m_max)
+        self.register_buffer("E1", E1)
+        self.register_buffer("E2", E2)
+        self.register_buffer("lambda_sat", torch.tensor(float(lambda_sat), dtype=dtype))
+        self.register_buffer("eps", torch.tensor(float(eps), dtype=dtype))
+        self.register_buffer("prefactor", torch.tensor(prefactor, dtype = dtype))
+
+    def forward(self, m, node_attrs):
+        abs_m = torch.abs(m).view(-1)
+
+        if node_attrs.dim() == 3:
+            node_attrs = node_attrs.squeeze(-1)
+
+        E = torch.zeros_like(abs_m)
+        # skip if zero initialized 
+        if all(torch.isclose(self.prefactor, torch.zeros_like(self.prefactor))):
+            return E
+        
+        for s in range(self.n_species):
+
+            m0 = self.m_max[s]
+
+            # excess moment
+            dm = torch.clamp(abs_m - m0, min=0.0)
+
+            # blow up at |m| = 1.1 * m0
+            dm_max = (self.prefactor[s] - 1.0) * m0
+            
+            y = dm / dm_max
+            y = torch.clamp(y, max=1.0 - self.eps)
+
+            # C2-matching polynomial
+            poly = self.E1[s] * dm + 0.5 * self.E2[s] * dm * dm
+
+            # logarithmic wall
+            wall = (2*y)**3 / (1.0 - y + self.eps)**2
+            wall_term = self.lambda_sat * wall
+            # wall = -torch.log(1.0 - y**2 + self.eps)
+            # wall_term = self.lambda_sat * ((2 * y) ** 3) * wall
+
+            Es = poly + wall_term
+            E = E + node_attrs[:, s] * Es
+        return E
+
+
+@compile_mode("script")
+class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesEvenSplineSelfMagmomScaleShiftMACE(MagneticMACE):
+    def __init__(
+        self,
+        atomic_inter_scale: float,
+        atomic_inter_shift: float,
+        **kwargs,
+    ):
+    
+        self.m_max_1b = kwargs.pop("m_max_1b")
+        super().__init__(**kwargs)
+        self.scale_shift = ScaleShiftBlock(
+            scale=atomic_inter_scale, shift=0.0
+        )
+
+        # modify spherical to solid harmonics for magnetic moment
+        self.mag_solid_harmoics = SHModule(self.mag_spherical_harmonics._lmax)
+        self.mag_spherical_harmonics = None
+        self.magmom_readouts = None
+        self.magmom_products = None
+
+        # coefficient for the chebyshev polynomails
+        self.E_m_spline = EvenSpline1Body(self.m_max_1b)
+        
+        # barrier
+        # self, m_max, E1, E2, lambda_sat=0.05, eps=1e-8, dtype=None
+        self.saturation = EvenMagSaturationBarrier(self.m_max_1b, 
+                                                   np.zeros_like(self.m_max_1b),
+                                                   np.zeros_like(self.m_max_1b),
+                                                   prefactor=np.zeros_like(self.m_max_1b)
+                                                   )
+
+        # correction to shift E0s for each species
+        self.register_buffer(
+            "one_body_magmom_const_correction", torch.zeros(len(self.atomic_numbers), len(self.heads))
+        )
+
+    def forward(
+        self,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
+        compute_force: bool = True,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_hessian: bool = False,
+        compute_magforces: bool = True,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # Setup
+        data["positions"].requires_grad_(True)
+        data["node_attrs"].requires_grad_(True)
+        data["magmom"].requires_grad_(True)
+        
+        num_graphs = data["ptr"].numel() - 1
+        num_atoms_arange = torch.arange(data["positions"].shape[0])
+        node_heads = (
+            data["head"][data["batch"]]
+            if "head" in data
+            else torch.zeros_like(data["batch"])
+        )
+        displacement = torch.zeros(
+            (num_graphs, 3, 3),
+            dtype=data["positions"].dtype,
+            device=data["positions"].device,
+        )
+        if compute_virials or compute_stress or compute_displacement:
+            (
+                data["positions"],
+                data["shifts"],
+                displacement,
+            ) = get_symmetric_displacement(
+                positions=data["positions"],
+                unit_shifts=data["unit_shifts"],
+                cell=data["cell"],
+                edge_index=data["edge_index"],
+                num_graphs=num_graphs,
+                batch=data["batch"],
+            )
+
+        # Atomic energies
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])[
+            num_atoms_arange, node_heads
+        ]
+        e0 = scatter_sum(
+            src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
+        )  # [n_graphs, num_heads]
+
+        # node embedding on species
+        node_feats = self.node_embedding(data["node_attrs"])
+
+        # prepare the Rnl and Ylm
+        vectors, lengths = get_edge_vectors_and_lengths(
+            positions=data["positions"],
+            edge_index=data["edge_index"],
+            shifts=data["shifts"],
+        )
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+        if hasattr(self, "pair_repulsion"):
+            pair_node_energy = self.pair_repulsion_fn(
+                lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+            )
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+
+        # --- magnetic stuffs ---
+        
+        magmom_lenghts = torch.norm(data["magmom"], dim=-1, keepdim=True)
+        element_dependent_scaling = self.m_max[torch.argmax(data["node_attrs"], dim=1)].unsqueeze(-1)
+        element_dependent_scaling.requires_grad_(True)
+        element_dependent_scaling.retain_grad()
+        
+        magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling) ** 2
+        magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
+
+        #
+        magmom_node_feats = self.mag_radial_embedding(magmom_lenghts_trans) # (n_atoms, n_basis)
+        
+        # Interactions
+        node_es_list = [pair_node_energy]
+        node_feats_list = []
+        magmom_node_feats_list = []
+        for (idx, (interaction, product, readout)) in enumerate(zip(
+            self.interactions, self.products, self.readouts
+        )):
+            node_feats, sc = interaction(
+                node_attrs=data["node_attrs"],
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs
+            )
+          
+            node_feats = product(
+                node_feats=node_feats, sc=sc,node_attrs=data["node_attrs"], 
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs,
+            )
+            
+            node_feats_list.append(node_feats)
+            node_es_list.append(
+                readout(node_feats, node_heads)[num_atoms_arange, node_heads]
+            )  # {[n_nodes, ], }
+
+        # assume only single head
+        onebody_magmom_contri = self.E_m_spline(magmom_lenghts, data['node_attrs']).unsqueeze(-1)
+        
+        #
+        one_body_correction = torch.einsum(
+                    'ns,sh->nh', data["node_attrs"], self.one_body_magmom_const_correction
+                )
+        assert one_body_correction.shape[1] == 1
+        # apply correction so that the zero matches E0 exactly
+        onebody_magmom_contri -=  one_body_correction
+
+        if self.saturation is not None:
+            saturation_correction = self.saturation(magmom_lenghts, data['node_attrs']).unsqueeze(-1)
+            onebody_magmom_contri += saturation_correction
+
+        # Concatenate node features
+        node_feats_out = torch.cat(node_feats_list, dim=-1) 
+
+        # Sum over interactions
+        node_inter_es = torch.sum(
+            torch.stack(node_es_list, dim=0), dim=0
+        )  # [n_nodes, ]
+        node_inter_es = self.scale_shift(node_inter_es, node_heads)
+        node_inter_es += onebody_magmom_contri[:, 0]
+        # Sum over nodes in graph
+        inter_e = scatter_sum(
+            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+        
+        # Add E_0 and (scaled) interaction energy
+        total_energy = e0 + inter_e
+        node_energy = node_e0 + node_inter_es
+        forces, virials, stress, hessian, magforces = get_outputs(
+            energy=inter_e,
+            positions=data["positions"],
+            displacement=displacement,
+            cell=data["cell"],
+            magmoms=data["magmom"],
+            training=training,
+            compute_force=compute_force,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_hessian=compute_hessian,
+            compute_magforces=compute_magforces,
+        )
+        output = {
+            "energy": total_energy,
+            "node_energy": node_energy,
+            "interaction_energy": inter_e,
+            "forces": forces,
+            "magforces": magforces,
+            "virials": virials,
+            "stress": stress,
+            "hessian": hessian,
+            "displacement": displacement,
+            "node_feats": node_feats_out,
+        }
+        return output
+
+@compile_mode("script")
+class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesFixingGinzburgSelfMagmomScaleShiftMACE(MagneticMACE):
+    def __init__(
+        self,
+        atomic_inter_scale: float,
+        atomic_inter_shift: float,
+        **kwargs,
+    ):
+        num_mag_radial_basis_one_body = kwargs.pop("num_mag_radial_basis_one_body")
+        super().__init__(**kwargs)
+        self.scale_shift = ScaleShiftBlock(
+            scale=atomic_inter_scale, shift=0.0
+        )
+
+        # modify spherical to solid harmonics for magnetic moment
+        self.mag_solid_harmoics = SHModule(self.mag_spherical_harmonics._lmax)
+        self.mag_spherical_harmonics = None
+        self.magmom_readouts = None
+        self.magmom_products = None
+
+        self.onebody_magmombasis_list = torch.nn.ModuleList()
+
+        # coefficient for the chebyshev polynomails
+        self.onebody_magmombasis_coeffs = torch.nn.Parameter(torch.randn(len(self.atomic_numbers), num_mag_radial_basis_one_body, len(self.heads)))
+
+        self.one_body_cheb_basis_with_const = ChebychevBasisWithConst(
+            r_max = 1.0,
+            num_basis = num_mag_radial_basis_one_body,
+        )
+
+        # correction to shift E0s for each species
+        self.register_buffer(
+            "one_body_magmom_const_correction", torch.zeros(len(self.atomic_numbers), len(self.heads))
+        )
+
+    def forward(
+        self,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
+        compute_force: bool = True,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_hessian: bool = False,
+        compute_magforces: bool = True,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # Setup
+        data["positions"].requires_grad_(True)
+        data["node_attrs"].requires_grad_(True)
+        data["magmom"].requires_grad_(True)
+        
+        num_graphs = data["ptr"].numel() - 1
+        num_atoms_arange = torch.arange(data["positions"].shape[0])
+        node_heads = (
+            data["head"][data["batch"]]
+            if "head" in data
+            else torch.zeros_like(data["batch"])
+        )
+        displacement = torch.zeros(
+            (num_graphs, 3, 3),
+            dtype=data["positions"].dtype,
+            device=data["positions"].device,
+        )
+        if compute_virials or compute_stress or compute_displacement:
+            (
+                data["positions"],
+                data["shifts"],
+                displacement,
+            ) = get_symmetric_displacement(
+                positions=data["positions"],
+                unit_shifts=data["unit_shifts"],
+                cell=data["cell"],
+                edge_index=data["edge_index"],
+                num_graphs=num_graphs,
+                batch=data["batch"],
+            )
+
+        # Atomic energies
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])[
+            num_atoms_arange, node_heads
+        ]
+        e0 = scatter_sum(
+            src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
+        )  # [n_graphs, num_heads]
+
+        # node embedding on species
+        node_feats = self.node_embedding(data["node_attrs"])
+
+        # prepare the Rnl and Ylm
+        vectors, lengths = get_edge_vectors_and_lengths(
+            positions=data["positions"],
+            edge_index=data["edge_index"],
+            shifts=data["shifts"],
+        )
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+        if hasattr(self, "pair_repulsion"):
+            pair_node_energy = self.pair_repulsion_fn(
+                lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+            )
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+
+        # --- magnetic stuffs ---
+        
+        magmom_lenghts = torch.norm(data["magmom"], dim=-1, keepdim=True)
+        element_dependent_scaling = self.m_max[torch.argmax(data["node_attrs"], dim=1)].unsqueeze(-1)
+        element_dependent_scaling.requires_grad_(True)
+        element_dependent_scaling.retain_grad()
+        
+        magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling)
+        magmom_lenghts_trans_1b = 1 - 2 * (magmom_lenghts / element_dependent_scaling) ** 2
+        magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
+
+        #
+        magmom_node_feats = self.mag_radial_embedding(magmom_lenghts_trans) # (n_atoms, n_basis)
+
+        # one body contribution radials, this is with constant shift so that it can be fitted
+        magmom_one_body_radials = self.one_body_cheb_basis_with_const(
+            magmom_lenghts_trans_1b
         )
         
         # Interactions
@@ -4294,102 +5060,6 @@ class EnergyDipolesMACE(torch.nn.Module):
 # for a given position. Still later we can do something like:
 # given position also predict the magnetic moment based on the previous magnetic moment
 # to accelerate SCF cycles that have to be done
-# class MagneticSCFMACE(torch.nn.Module):
-#     def __init__(self, model, n_scf_step=10, scf_tol=1e-5, scf_logging=False, scf_step_size=1.0, use_scf = True):
-#         super().__init__()
-#         self.magmom_mace = model # original magnetic mace
-#         self.n_scf_step = n_scf_step
-#         self.scf_tol = scf_tol
-#         self.cache_magmom = None
-#         self.scf_logging = scf_logging
-#         self.scf_step_size = scf_step_size
-#         self.use_scf = use_scf
- 
-#         self.cache_magmom = None
-
-#     def forward(
-#         self,
-#         data: Dict[str, torch.Tensor],
-#         training: bool = False,
-#         compute_force: bool = True,
-#         compute_virials: bool = False,
-#         compute_stress: bool = False,
-#         compute_displacement: bool = False,
-#     ) -> Dict[str, Optional[torch.Tensor]]:
-        
-#         device = next(self.magmom_mace.parameters()).device
-
-        
-#         # === Initialize magmom ===
-#         if "magmom" in data:
-#             magmom = data["magmom"].detach().to(device).clone()
-#         elif self.cache_magmom is not None:
-#             magmom = self.cache_magmom.clone()
-#         else:
-#             raise ValueError("No initial magnetic moment provided and no cache available.")
-
-#         magmom = magmom.to(device)
-#         magmom.requires_grad_(True)
-#         energy_history = []
-
-#         # === Define optimizer ===
-#         if self.use_scf:
-#             optimizer = torch.optim.LBFGS([magmom], max_iter=self.n_scf_step, tolerance_grad=self.scf_tol, \
-#                                           line_search_fn="strong_wolfe", lr=self.scf_step_size)
-
-#             def closure():
-#                 optimizer.zero_grad()
-
-#                 # Update magnetic moments in config
-#                 data["magmom"] = magmom
-
-#                 # Evaluate model
-#                 output = self.magmom_mace(
-#                     data,
-#                     training=training,
-#                     compute_force=compute_force,
-#                     compute_virials=compute_virials,
-#                     compute_stress=compute_stress,
-#                     compute_displacement=compute_displacement,
-#                 )
-
-#                 energy = output["energy"][0]
-#                 energy_history.append(energy.item())
-
-#                 # Set gradient manually from mag_forces
-#                 magmom.grad = -output["magforces"].detach()
-#                 if self.scf_logging:
-#                     print(f"[SCF LBFGS] Energy = {energy.item():.6f} | Mag force norm = {magmom.grad.norm().item():.6f}")
-#                 return energy
-
-#             optimizer.step(closure)
-
-#             # Cache final magnetic moments
-#             self.cache_magmom = magmom.detach()
-
-#             # Final output (evaluate one last time with final magmom)
-#             data["dft_magmom"] = magmom
-
-#         final_output = self.magmom_mace(
-#             data,
-#             training=training,
-#             compute_force=compute_force,
-#             compute_virials=compute_virials,
-#             compute_stress=compute_stress,
-#             compute_displacement=compute_displacement,
-#         )
-
-#         # Add SCF info to output
-#         final_output["scf_energy_history"] = torch.tensor(energy_history, dtype=torch.float32)
-#         final_output["scf_steps"] = len(energy_history)
-#         final_output["equilibrated_magmom"] = magmom.detach()
-
-#         return final_output
-
-# this does not differentiate through SCF but just a convenient wrapper for equilibrating magmom 
-# for a given position. Still later we can do something like:
-# given position also predict the magnetic moment based on the previous magnetic moment
-# to accelerate SCF cycles that have to be done
 class MagneticSCFMACE(torch.nn.Module):
     """
     SCF wrapper for magnetic moment equilibration under an applied magnetic field.
@@ -4404,6 +5074,7 @@ class MagneticSCFMACE(torch.nn.Module):
         use_scf=True,
         return_magmom_hist=False,
         constrain_magnitude=False,
+        use_collinear=False,
     ):
         super().__init__()
         self.magmom_mace = model
@@ -4414,7 +5085,7 @@ class MagneticSCFMACE(torch.nn.Module):
         self.use_scf = use_scf
         self.return_magmom_hist = return_magmom_hist
         self.constrain_magnitude = constrain_magnitude
-
+        self.use_collinear = use_collinear
         self.cache_magmom = None
 
     def forward(
@@ -4443,7 +5114,7 @@ class MagneticSCFMACE(torch.nn.Module):
         energy_history = []
         grad_norm_history = []
         scf_iter = []
-        magmom_history = [magmom.detach().clone(),]
+        magmom_history = []
         # === Prepare applied magnetic field ===
         if applied_B_field is not None:
             applied_B_field = applied_B_field.to(device)
@@ -4509,6 +5180,18 @@ class MagneticSCFMACE(torch.nn.Module):
                     # g_parallel = g - (g·n)n
                     raw_grad = raw_grad - (raw_grad * mu_norm).sum(dim=1, keepdim=True) * mu_norm
 
+                # ----------------------------------
+                # Gradient clipping (global norm)
+                # ----------------------------------
+                # max_grad_norm = 1.0  # tune this (0.01–0.2 typical)
+
+                # grad_norm = raw_grad.norm()
+                # if grad_norm > max_grad_norm:
+                #     raw_grad = raw_grad * (max_grad_norm / (grad_norm + 1e-12))
+                # after computing raw_grad
+                if self.use_collinear:
+                    raw_grad[:, 0] = 0.0
+                    raw_grad[:, 1] = 0.0
                 # assign gradient manually
                 magmom.grad = raw_grad
 
@@ -4633,8 +5316,8 @@ class MagneticSCFMACE(torch.nn.Module):
             zeeman_energy = -mu_B * (magmom * applied_B_field).sum()
             final_output["energy"] = final_output["energy"] + zeeman_energy
 
-        final_output["scf_energy_history"] = torch.tensor(energy_history, dtype=torch.float32)
-        final_output["grad_norm_history"] = torch.tensor(grad_norm_history, dtype=torch.float32)
+        final_output["scf_energy_history"] = torch.tensor(energy_history, dtype=torch.float64)
+        final_output["grad_norm_history"] = torch.tensor(grad_norm_history, dtype=torch.float64)
         final_output["scf_steps"] = len(energy_history)
         final_output["equilibrated_magmom"] = magmom.detach()
         final_output["applied_field"] = applied_B_field

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -21,6 +21,7 @@ from .blocks import (
     EquivariantProductBasisBlock,
     EquivariantProductBasisWithSelfMagmomBlock,
     EquivariantProductBasisWithOneBodySelfMagmomBlock,
+    EquivariantProductBasisNonSOCWithSelfMagmomBlock,
     InteractionBlock,
     LinearDipoleReadoutBlock,
     LinearNodeEmbeddingBlock,
@@ -625,35 +626,61 @@ class MagneticMACE(torch.nn.Module):
                 cueq_config=cueq_config,
                 contraction_cls=contraction_cls_first)
         else:
-            if "OneBody" not in self.__class__.__name__:
-                prod_block_cls = EquivariantProductBasisWithSelfMagmomBlock
+            if "NonSpinOrbitCoupled" in self.__class__.__name__:
+                # import pdb; pdb.set_trace()
+                prod = EquivariantProductBasisNonSOCWithSelfMagmomBlock(
+                node_feats_irreps=node_feats_irreps_out,
+                target_irreps=hidden_irreps,
+                correlation=correlation[0],
+                num_elements=num_elements,
+                use_sc=use_sc_first,
+                cueq_config=cueq_config,
+                contraction_cls=contraction_cls_first,
+                magmom_node_inv_feats_irreps=o3.Irreps(f"{self.mag_radial_embedding.num_basis}x0e"),
+                magmom_node_attrs_irreps=o3.Irreps.spherical_harmonics(self.mag_spherical_harmonics._lmax)                    
+                )
+                magmom_prod = EquivariantProductBasisNonSOCWithSelfMagmomBlock(
+                    node_feats_irreps=node_feats_irreps_out,
+                    target_irreps=hidden_irreps,
+                    correlation=correlation[0],
+                    num_elements=num_elements,
+                    use_sc=use_sc_first,
+                    cueq_config=cueq_config,
+                    contraction_cls=contraction_cls_first,
+                    magmom_node_inv_feats_irreps=o3.Irreps(f"{self.mag_radial_embedding.num_basis}x0e"),
+                    magmom_node_attrs_irreps=o3.Irreps.spherical_harmonics(self.mag_spherical_harmonics._lmax)
+                    )
             else:
-                if "Readout" in self.__class__.__name__ or "Ginzburg" in self.__class__.__name__:
+                if "OneBody" not in self.__class__.__name__:
                     prod_block_cls = EquivariantProductBasisWithSelfMagmomBlock
                 else:
-                    prod_block_cls = EquivariantProductBasisWithOneBodySelfMagmomBlock
-            prod = prod_block_cls(
-                node_feats_irreps=node_feats_irreps_out,
-                target_irreps=hidden_irreps,
-                # assume only a single correlation
-                correlation=correlation[0],
-                use_sc=use_sc_first,
-                num_elements=len(self.atomic_numbers),
-                cueq_config=cueq_config,
-                magmom_node_inv_feats_irreps=o3.Irreps(f"{self.mag_radial_embedding.num_basis}x0e"),
-                magmom_node_attrs_irreps=o3.Irreps.spherical_harmonics(self.mag_spherical_harmonics._lmax)
-            )
-            magmom_prod = prod_block_cls(
-                node_feats_irreps=node_feats_irreps_out,
-                target_irreps=hidden_irreps,
-                # assume only a single correlation
-                correlation=correlation[0],
-                use_sc=use_sc_first,
-                num_elements=len(self.atomic_numbers),
-                cueq_config=cueq_config,
-                magmom_node_inv_feats_irreps=o3.Irreps(f"{self.mag_radial_embedding.num_basis}x0e"),
-                magmom_node_attrs_irreps=o3.Irreps.spherical_harmonics(self.mag_spherical_harmonics._lmax)
+                    if "Readout" in self.__class__.__name__ or "Ginzburg" in self.__class__.__name__:
+                        prod_block_cls = EquivariantProductBasisWithSelfMagmomBlock
+                    else:
+                        prod_block_cls = EquivariantProductBasisWithOneBodySelfMagmomBlock
+
+                prod = prod_block_cls(
+                    node_feats_irreps=node_feats_irreps_out,
+                    target_irreps=hidden_irreps,
+                    # assume only a single correlation
+                    correlation=correlation[0],
+                    use_sc=use_sc_first,
+                    num_elements=len(self.atomic_numbers),
+                    cueq_config=cueq_config,
+                    magmom_node_inv_feats_irreps=o3.Irreps(f"{self.mag_radial_embedding.num_basis}x0e"),
+                    magmom_node_attrs_irreps=o3.Irreps.spherical_harmonics(self.mag_spherical_harmonics._lmax)
                 )
+                magmom_prod = prod_block_cls(
+                    node_feats_irreps=node_feats_irreps_out,
+                    target_irreps=hidden_irreps,
+                    # assume only a single correlation
+                    correlation=correlation[0],
+                    use_sc=use_sc_first,
+                    num_elements=len(self.atomic_numbers),
+                    cueq_config=cueq_config,
+                    magmom_node_inv_feats_irreps=o3.Irreps(f"{self.mag_radial_embedding.num_basis}x0e"),
+                    magmom_node_attrs_irreps=o3.Irreps.spherical_harmonics(self.mag_spherical_harmonics._lmax)
+                    )
 
         self.products = torch.nn.ModuleList([prod])
         self.magmom_products = torch.nn.ModuleList([magmom_prod])
@@ -1489,7 +1516,10 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(Magneti
         # Interactions
         node_es_list = [pair_node_energy]
         node_feats_list = []
-        magmom_node_feats_list = []
+        
+
+        # one_body_magmom_energy = onebody_magmom_contri[num_atoms_arange, node_heads]
+
         for interaction, product, readout in zip(
             self.interactions, self.products, self.readouts
         ):
@@ -2047,6 +2077,7 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleSh
         element_dependent_scaling.retain_grad()
         
         magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling) ** 2
+        # print("magmom_lenghts_trans: ", torch.max(magmom_lenghts_trans).item())
         magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
 
         #
@@ -2060,7 +2091,11 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleSh
         # Interactions
         node_es_list = [pair_node_energy]
         node_feats_list = []
-        magmom_node_feats_list = []
+        
+        # one body magmo contribution
+        # one_body_magmom_energy = onebody_magmombasis[num_atoms_arange, node_heads] - self.one_body_magmom_const_correction
+        onebody_magmom_contri = 0.0
+
         for (idx, (interaction, product, readout, onebody_magmombasis)) in enumerate(zip(
             self.interactions, self.products, self.readouts, self.onebody_magmombasis_list
         )):
@@ -2136,6 +2171,7 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleSh
             "hessian": hessian,
             "displacement": displacement,
             "node_feats": node_feats_out,
+            "one_body_magmom_energy": torch.sum(onebody_magmom_contri),
         }
         return output
 
@@ -2252,6 +2288,7 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfM
         element_dependent_scaling.retain_grad()
         
         magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling) ** 2
+        # magmom_lenghts_trans_1b = 1 - 2 * (magmom_lenghts / 4.0) ** 2
         magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
 
         #
@@ -2358,6 +2395,460 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfM
             "node_feats": node_feats_out,
         }
         return output
+
+
+@compile_mode("script")
+class MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(MagneticMACE):
+    def __init__(
+        self,
+        atomic_inter_scale: float,
+        atomic_inter_shift: float,
+        **kwargs,
+    ):
+        num_mag_radial_basis_one_body = kwargs.pop("num_mag_radial_basis_one_body")
+        super().__init__(**kwargs)
+        self.scale_shift = ScaleShiftBlock(
+            scale=atomic_inter_scale, shift=0.0
+        )
+
+        # modify spherical to solid harmonics for magnetic moment
+        self.mag_solid_harmoics = SHModule(self.mag_spherical_harmonics._lmax)
+        self.mag_spherical_harmonics = None
+        self.magmom_readouts = None
+        #self.magmom_products = None
+
+        self.onebody_magmombasis_list = torch.nn.ModuleList()
+
+        # coefficient for the chebyshev polynomails
+        self.onebody_magmombasis_coeffs = torch.nn.Parameter(torch.randn(len(self.atomic_numbers), num_mag_radial_basis_one_body, len(self.heads)))
+
+        self.one_body_cheb_basis_with_const = ChebychevBasisWithConst(
+            r_max = 1.0,
+            num_basis = num_mag_radial_basis_one_body,
+        )
+
+        # correction to shift E0s for each species
+        self.register_buffer(
+            "one_body_magmom_const_correction", torch.zeros(len(self.atomic_numbers), len(self.heads))
+        )
+
+    def forward(
+        self,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
+        compute_force: bool = True,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_hessian: bool = False,
+        compute_magforces: bool = True,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # Setup
+        data["positions"].requires_grad_(True)
+        data["node_attrs"].requires_grad_(True)
+        data["magmom"].requires_grad_(True)
+        
+        num_edges = data["edge_index"].shape[0]
+        num_graphs = data["ptr"].numel() - 1
+        num_atoms_arange = torch.arange(data["positions"].shape[0])
+        node_heads = (
+            data["head"][data["batch"]]
+            if "head" in data
+            else torch.zeros_like(data["batch"])
+        )
+        displacement = torch.zeros(
+            (num_graphs, 3, 3),
+            dtype=data["positions"].dtype,
+            device=data["positions"].device,
+        )
+        if compute_virials or compute_stress or compute_displacement:
+            (
+                data["positions"],
+                data["shifts"],
+                displacement,
+            ) = get_symmetric_displacement(
+                positions=data["positions"],
+                unit_shifts=data["unit_shifts"],
+                cell=data["cell"],
+                edge_index=data["edge_index"],
+                num_graphs=num_graphs,
+                batch=data["batch"],
+            )
+
+        # Atomic energies
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])[
+            num_atoms_arange, node_heads
+        ]
+        e0 = scatter_sum(
+            src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
+        )  # [n_graphs, num_heads]
+
+        # node embedding on species
+        node_feats = self.node_embedding(data["node_attrs"])
+
+        # prepare the Rnl and Ylm
+        vectors, lengths = get_edge_vectors_and_lengths(
+            positions=data["positions"],
+            edge_index=data["edge_index"],
+            shifts=data["shifts"],
+        )
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+        if hasattr(self, "pair_repulsion"):
+            pair_node_energy = self.pair_repulsion_fn(
+                lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+            )
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+
+        # --- magnetic stuffs ---
+        
+        magmom_lenghts = torch.norm(data["magmom"], dim=-1, keepdim=True)
+        element_dependent_scaling = self.m_max[torch.argmax(data["node_attrs"], dim=1)].unsqueeze(-1)
+        element_dependent_scaling.requires_grad_(True)
+        element_dependent_scaling.retain_grad()
+        
+        magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling) ** 2
+        
+        magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
+
+        #
+        magmom_node_feats = self.mag_radial_embedding(magmom_lenghts_trans) # (n_atoms, n_basis)
+
+        # one body contribution radials, this is with constant shift so that it can be fitted
+        magmom_one_body_radials = self.one_body_cheb_basis_with_const(
+            magmom_lenghts_trans
+        )
+        
+        # Interactions
+        node_es_list = [pair_node_energy]
+        node_feats_list = []
+        
+        for (idx, (interaction, product, magmom_product, readout)) in enumerate(zip(
+            self.interactions, self.products, self.magmom_products, self.readouts
+        )):
+            
+            noSO_node_feats, noSO_sc, noSO_magmom_node_feats, \
+                noSO_magmom_sc, SO_magmom_node_feats, SO_sc = interaction(
+                node_attrs=data["node_attrs"],
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs
+            )
+          
+            noSO_node_feats = product(
+                node_feats=noSO_node_feats, sc=noSO_sc ,node_attrs=data["node_attrs"], 
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs,
+            )
+            
+            noSO_magmom_node_feats = magmom_product(node_feats=noSO_magmom_node_feats, sc=noSO_magmom_sc,node_attrs=data["node_attrs"],
+                                                    magmom_node_inv_feats=magmom_node_feats,magmom_node_attrs=magmom_node_attrs,)
+
+            
+            node_feats_list.append(node_feats)
+            if idx == (len(self.readouts) - 1):    
+                # linear (natom, num_basis) -> (natom, 1)
+                # remove certain constant to make it matches with E0, 
+                # self.one_body_magmom_const_correction is computed outside after pre-training
+                # Select the correct coefficient row for each atom via einsum
+                selected_coeffs = torch.einsum(
+                    "ns,sbh->nbh", data["node_attrs"], self.onebody_magmombasis_coeffs
+                )
+                #
+                one_body_correction = torch.einsum(
+                    'ns,sh->nh', data["node_attrs"], self.one_body_magmom_const_correction
+                )
+                # Compute dot product over nbasis → (n_nodes, num_heads)
+                onebody_magmom_contri = (magmom_one_body_radials.unsqueeze(-1) * selected_coeffs).sum(dim=1)
+
+                # apply correction so that the zero matches E0 exactly
+                onebody_magmom_contri -= one_body_correction
+
+                # Gather energy per atom + one-body magmom contribution for each head
+                node_es_list.append(
+                    readout(noSO_node_feats + noSO_magmom_node_feats, node_heads)[num_atoms_arange, node_heads] +
+                    onebody_magmom_contri[num_atoms_arange, node_heads]
+                )
+            else:
+                node_es_list.append(
+                    readout(noSO_node_feats + noSO_magmom_node_feats, node_heads)[num_atoms_arange, node_heads]
+                )  # {[n_nodes, ], }
+
+
+        # Concatenate node features
+        node_feats_out = torch.cat(node_feats_list, dim=-1) 
+
+        # Sum over interactions
+        node_inter_es = torch.sum(
+            torch.stack(node_es_list, dim=0), dim=0
+        )  # [n_nodes, ]
+        node_inter_es = self.scale_shift(node_inter_es, node_heads)
+
+        # Sum over nodes in graph
+        inter_e = scatter_sum(
+            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+        
+        # Add E_0 and (scaled) interaction energy
+        total_energy = e0 + inter_e
+        node_energy = node_e0 + node_inter_es
+        forces, virials, stress, hessian, magforces = get_outputs(
+            energy=inter_e,
+            positions=data["positions"],
+            displacement=displacement,
+            cell=data["cell"],
+            magmoms=data["magmom"],
+            training=training,
+            compute_force=compute_force,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_hessian=compute_hessian,
+            compute_magforces=compute_magforces,
+        )
+        output = {
+            "energy": total_energy,
+            "node_energy": node_energy,
+            "interaction_energy": inter_e,
+            "forces": forces,
+            "magforces": magforces,
+            "virials": virials,
+            "stress": stress,
+            "hessian": hessian,
+            "displacement": displacement,
+            "node_feats": node_feats_out,
+        }
+        return output
+
+@compile_mode("script")
+class MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(MagneticMACE):
+    def __init__(
+        self,
+        atomic_inter_scale: float,
+        atomic_inter_shift: float,
+        **kwargs,
+    ):
+        num_mag_radial_basis_one_body = kwargs.pop("num_mag_radial_basis_one_body")
+        super().__init__(**kwargs)
+        self.scale_shift = ScaleShiftBlock(
+            scale=atomic_inter_scale, shift=0.0
+        )
+
+        # modify spherical to solid harmonics for magnetic moment
+        self.mag_solid_harmoics = SHModule(self.mag_spherical_harmonics._lmax)
+        self.mag_spherical_harmonics = None
+        self.magmom_readouts = None
+        #self.magmom_products = None
+
+        self.onebody_magmombasis_list = torch.nn.ModuleList()
+
+        # coefficient for the chebyshev polynomails
+        self.onebody_magmombasis_coeffs = torch.nn.Parameter(torch.randn(len(self.atomic_numbers), num_mag_radial_basis_one_body, len(self.heads)))
+
+        self.one_body_cheb_basis_with_const = ChebychevBasisWithConst(
+            r_max = 1.0,
+            num_basis = num_mag_radial_basis_one_body,
+        )
+
+        # correction to shift E0s for each species
+        self.register_buffer(
+            "one_body_magmom_const_correction", torch.zeros(len(self.atomic_numbers), len(self.heads))
+        )
+
+    def forward(
+        self,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
+        compute_force: bool = True,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_hessian: bool = False,
+        compute_magforces: bool = True,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # Setup
+        data["positions"].requires_grad_(True)
+        data["node_attrs"].requires_grad_(True)
+        data["magmom"].requires_grad_(True)
+        
+        num_edges = data["edge_index"].shape[0]
+        num_graphs = data["ptr"].numel() - 1
+        num_atoms_arange = torch.arange(data["positions"].shape[0])
+        node_heads = (
+            data["head"][data["batch"]]
+            if "head" in data
+            else torch.zeros_like(data["batch"])
+        )
+        displacement = torch.zeros(
+            (num_graphs, 3, 3),
+            dtype=data["positions"].dtype,
+            device=data["positions"].device,
+        )
+        if compute_virials or compute_stress or compute_displacement:
+            (
+                data["positions"],
+                data["shifts"],
+                displacement,
+            ) = get_symmetric_displacement(
+                positions=data["positions"],
+                unit_shifts=data["unit_shifts"],
+                cell=data["cell"],
+                edge_index=data["edge_index"],
+                num_graphs=num_graphs,
+                batch=data["batch"],
+            )
+
+        # Atomic energies
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])[
+            num_atoms_arange, node_heads
+        ]
+        e0 = scatter_sum(
+            src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
+        )  # [n_graphs, num_heads]
+
+        # node embedding on species
+        node_feats = self.node_embedding(data["node_attrs"])
+
+        # prepare the Rnl and Ylm
+        vectors, lengths = get_edge_vectors_and_lengths(
+            positions=data["positions"],
+            edge_index=data["edge_index"],
+            shifts=data["shifts"],
+        )
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+        if hasattr(self, "pair_repulsion"):
+            pair_node_energy = self.pair_repulsion_fn(
+                lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+            )
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+
+        # --- magnetic stuffs ---
+        
+        magmom_lenghts = torch.norm(data["magmom"], dim=-1, keepdim=True)
+        element_dependent_scaling = self.m_max[torch.argmax(data["node_attrs"], dim=1)].unsqueeze(-1)
+        element_dependent_scaling.requires_grad_(True)
+        element_dependent_scaling.retain_grad()
+        
+        magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling) ** 2
+        
+        magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
+
+        #
+        magmom_node_feats = self.mag_radial_embedding(magmom_lenghts_trans) # (n_atoms, n_basis)
+
+        # one body contribution radials, this is with constant shift so that it can be fitted
+        magmom_one_body_radials = self.one_body_cheb_basis_with_const(
+            magmom_lenghts_trans
+        )
+        
+        # Interactions
+        node_es_list = [pair_node_energy]
+        node_feats_list = []
+        
+        for (idx, (interaction, product, magmom_product, readout)) in enumerate(zip(
+            self.interactions, self.products, self.magmom_products, self.readouts
+        )):
+            
+            node_feats, sc, _, \
+                _, _, _ = interaction(
+                node_attrs=data["node_attrs"],
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs
+            )
+          
+            node_feats = product(
+                node_feats=node_feats, sc=sc ,node_attrs=data["node_attrs"], 
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs,
+            )
+            
+            node_feats_list.append(node_feats)
+            if idx == (len(self.readouts) - 1):    
+                # linear (natom, num_basis) -> (natom, 1)
+                # remove certain constant to make it matches with E0, 
+                # self.one_body_magmom_const_correction is computed outside after pre-training
+                # Select the correct coefficient row for each atom via einsum
+                selected_coeffs = torch.einsum(
+                    "ns,sbh->nbh", data["node_attrs"], self.onebody_magmombasis_coeffs
+                )
+                #
+                one_body_correction = torch.einsum(
+                    'ns,sh->nh', data["node_attrs"], self.one_body_magmom_const_correction
+                )
+                # Compute dot product over nbasis → (n_nodes, num_heads)
+                onebody_magmom_contri = (magmom_one_body_radials.unsqueeze(-1) * selected_coeffs).sum(dim=1)
+
+                # apply correction so that the zero matches E0 exactly
+                onebody_magmom_contri -= one_body_correction
+
+                # Gather energy per atom + one-body magmom contribution for each head
+                node_es_list.append(
+                    readout(node_feats, node_heads)[num_atoms_arange, node_heads] +
+                    onebody_magmom_contri[num_atoms_arange, node_heads]
+                )
+            else:
+                node_es_list.append(
+                    readout(node_feats, node_heads)[num_atoms_arange, node_heads]
+                )  # {[n_nodes, ], }
+
+
+        # Concatenate node features
+        node_feats_out = torch.cat(node_feats_list, dim=-1) 
+
+        # Sum over interactions
+        node_inter_es = torch.sum(
+            torch.stack(node_es_list, dim=0), dim=0
+        )  # [n_nodes, ]
+        node_inter_es = self.scale_shift(node_inter_es, node_heads)
+
+        # Sum over nodes in graph
+        inter_e = scatter_sum(
+            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+        
+        # Add E_0 and (scaled) interaction energy
+        total_energy = e0 + inter_e
+        node_energy = node_e0 + node_inter_es
+        forces, virials, stress, hessian, magforces = get_outputs(
+            energy=inter_e,
+            positions=data["positions"],
+            displacement=displacement,
+            cell=data["cell"],
+            magmoms=data["magmom"],
+            training=training,
+            compute_force=compute_force,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_hessian=compute_hessian,
+            compute_magforces=compute_magforces,
+        )
+        output = {
+            "energy": total_energy,
+            "node_energy": node_energy,
+            "interaction_energy": inter_e,
+            "forces": forces,
+            "magforces": magforces,
+            "virials": virials,
+            "stress": stress,
+            "hessian": hessian,
+            "displacement": displacement,
+            "node_feats": node_feats_out,
+        }
+        return output
+
 
 @compile_mode("script")
 class MagneticSolidHarmonicsFlexibleSOScaleShiftMACE(MagneticMACE):
@@ -3803,18 +4294,127 @@ class EnergyDipolesMACE(torch.nn.Module):
 # for a given position. Still later we can do something like:
 # given position also predict the magnetic moment based on the previous magnetic moment
 # to accelerate SCF cycles that have to be done
+# class MagneticSCFMACE(torch.nn.Module):
+#     def __init__(self, model, n_scf_step=10, scf_tol=1e-5, scf_logging=False, scf_step_size=1.0, use_scf = True):
+#         super().__init__()
+#         self.magmom_mace = model # original magnetic mace
+#         self.n_scf_step = n_scf_step
+#         self.scf_tol = scf_tol
+#         self.cache_magmom = None
+#         self.scf_logging = scf_logging
+#         self.scf_step_size = scf_step_size
+#         self.use_scf = use_scf
+ 
+#         self.cache_magmom = None
+
+#     def forward(
+#         self,
+#         data: Dict[str, torch.Tensor],
+#         training: bool = False,
+#         compute_force: bool = True,
+#         compute_virials: bool = False,
+#         compute_stress: bool = False,
+#         compute_displacement: bool = False,
+#     ) -> Dict[str, Optional[torch.Tensor]]:
+        
+#         device = next(self.magmom_mace.parameters()).device
+
+        
+#         # === Initialize magmom ===
+#         if "magmom" in data:
+#             magmom = data["magmom"].detach().to(device).clone()
+#         elif self.cache_magmom is not None:
+#             magmom = self.cache_magmom.clone()
+#         else:
+#             raise ValueError("No initial magnetic moment provided and no cache available.")
+
+#         magmom = magmom.to(device)
+#         magmom.requires_grad_(True)
+#         energy_history = []
+
+#         # === Define optimizer ===
+#         if self.use_scf:
+#             optimizer = torch.optim.LBFGS([magmom], max_iter=self.n_scf_step, tolerance_grad=self.scf_tol, \
+#                                           line_search_fn="strong_wolfe", lr=self.scf_step_size)
+
+#             def closure():
+#                 optimizer.zero_grad()
+
+#                 # Update magnetic moments in config
+#                 data["magmom"] = magmom
+
+#                 # Evaluate model
+#                 output = self.magmom_mace(
+#                     data,
+#                     training=training,
+#                     compute_force=compute_force,
+#                     compute_virials=compute_virials,
+#                     compute_stress=compute_stress,
+#                     compute_displacement=compute_displacement,
+#                 )
+
+#                 energy = output["energy"][0]
+#                 energy_history.append(energy.item())
+
+#                 # Set gradient manually from mag_forces
+#                 magmom.grad = -output["magforces"].detach()
+#                 if self.scf_logging:
+#                     print(f"[SCF LBFGS] Energy = {energy.item():.6f} | Mag force norm = {magmom.grad.norm().item():.6f}")
+#                 return energy
+
+#             optimizer.step(closure)
+
+#             # Cache final magnetic moments
+#             self.cache_magmom = magmom.detach()
+
+#             # Final output (evaluate one last time with final magmom)
+#             data["dft_magmom"] = magmom
+
+#         final_output = self.magmom_mace(
+#             data,
+#             training=training,
+#             compute_force=compute_force,
+#             compute_virials=compute_virials,
+#             compute_stress=compute_stress,
+#             compute_displacement=compute_displacement,
+#         )
+
+#         # Add SCF info to output
+#         final_output["scf_energy_history"] = torch.tensor(energy_history, dtype=torch.float32)
+#         final_output["scf_steps"] = len(energy_history)
+#         final_output["equilibrated_magmom"] = magmom.detach()
+
+#         return final_output
+
+# this does not differentiate through SCF but just a convenient wrapper for equilibrating magmom 
+# for a given position. Still later we can do something like:
+# given position also predict the magnetic moment based on the previous magnetic moment
+# to accelerate SCF cycles that have to be done
 class MagneticSCFMACE(torch.nn.Module):
-    def __init__(self, model, n_scf_step=10, scf_tol=1e-5, scf_logging=False, scf_step_size=1.0, use_scf = True):
+    """
+    SCF wrapper for magnetic moment equilibration under an applied magnetic field.
+    """
+    def __init__(
+        self,
+        model,
+        n_scf_step=10,
+        scf_tol=1e-5,
+        scf_logging=False,
+        scf_step_size=1.0,
+        use_scf=True,
+        return_magmom_hist=False,
+        constrain_magnitude=False,
+    ):
         super().__init__()
-        self.magmom_mace = model # original magnetic mace
+        self.magmom_mace = model
         self.n_scf_step = n_scf_step
         self.scf_tol = scf_tol
-        self.cache_magmom = None
         self.scf_logging = scf_logging
-        self.scf_step_size =scf_step_size
+        self.scf_step_size = scf_step_size
         self.use_scf = use_scf
+        self.return_magmom_hist = return_magmom_hist
+        self.constrain_magnitude = constrain_magnitude
 
-    def clean_cache(self,):
         self.cache_magmom = None
 
     def forward(
@@ -3825,11 +4425,11 @@ class MagneticSCFMACE(torch.nn.Module):
         compute_virials: bool = False,
         compute_stress: bool = False,
         compute_displacement: bool = False,
+        applied_B_field: Optional[torch.Tensor] = None,
     ) -> Dict[str, Optional[torch.Tensor]]:
         
         device = next(self.magmom_mace.parameters()).device
 
-        
         # === Initialize magmom ===
         if "magmom" in data:
             magmom = data["magmom"].detach().to(device).clone()
@@ -3841,19 +4441,39 @@ class MagneticSCFMACE(torch.nn.Module):
         magmom = magmom.to(device)
         magmom.requires_grad_(True)
         energy_history = []
+        grad_norm_history = []
+        scf_iter = []
+        magmom_history = [magmom.detach().clone(),]
+        # === Prepare applied magnetic field ===
+        if applied_B_field is not None:
+            applied_B_field = applied_B_field.to(device)
+            applied_B_field.requires_grad_(True)
+            if applied_B_field.ndim == 1:
+                # Broadcast same field to all atoms
+                applied_B_field = applied_B_field.unsqueeze(0).expand_as(magmom)
+            elif applied_B_field.shape != magmom.shape:
+                raise ValueError("applied_field must have shape (3,) or same as magmom")
+            
+        mu_B = 5.7883818060e-5  # eV/T
+        # === SCF optimization ===
+        self.original_magmom_magnitudes = magmom.norm(dim=1, keepdim=True).detach().clone()
 
-        # === Define optimizer ===
         if self.use_scf:
-            optimizer = torch.optim.LBFGS([magmom], max_iter=self.n_scf_step, tolerance_grad=self.scf_tol, \
-                                          line_search_fn="strong_wolfe", lr=self.scf_step_size)
+            optimizer = torch.optim.LBFGS(
+                [magmom],
+                max_iter=self.n_scf_step,
+                tolerance_grad=self.scf_tol,
+                line_search_fn="strong_wolfe",
+                lr=self.scf_step_size,
+            )
 
             def closure():
                 optimizer.zero_grad()
 
-                # Update magnetic moments in config
+                # attach current moment to data dict
                 data["magmom"] = magmom
 
-                # Evaluate model
+                # forward pass
                 output = self.magmom_mace(
                     data,
                     training=training,
@@ -3864,22 +4484,141 @@ class MagneticSCFMACE(torch.nn.Module):
                 )
 
                 energy = output["energy"][0]
-                energy_history.append(energy.item())
 
-                # Set gradient manually from mag_forces
-                magmom.grad = -output["magforces"].detach()
+                # --------------------------
+                # Compute gradient wrt μ
+                # --------------------------
+                raw_grad = -output["magforces"].detach()     # shape (N,3)
+
+                # Zeeman term contribution
+                if applied_B_field is not None:
+                    zeeman_energy = -mu_B * (magmom * applied_B_field).sum()
+                    energy = energy + zeeman_energy
+
+                    z_grad = -mu_B * applied_B_field.detach()
+                    raw_grad = raw_grad + z_grad
+
+                # --------------------------
+                # Optionally enforce |μ| fixed
+                # --------------------------
+                if self.constrain_magnitude:
+                    mu = magmom
+                    mu_norm = mu / (mu.norm(dim=1, keepdim=True) + 1e-12)
+
+                    # project gradient to tangent plane of sphere
+                    # g_parallel = g - (g·n)n
+                    raw_grad = raw_grad - (raw_grad * mu_norm).sum(dim=1, keepdim=True) * mu_norm
+
+                # assign gradient manually
+                magmom.grad = raw_grad
+
+                # optional logging
                 if self.scf_logging:
-                    print(f"[SCF LBFGS] Energy = {energy.item():.6f} | Mag force norm = {magmom.grad.norm().item():.6f}")
+                    print(" ===== ")
+                    print(f"[SCF LBFGS] Energy = {energy.item():.6f} | |Mag force| = {magmom.grad.norm().item():.6f}")
+                    if applied_B_field is not None:
+                        print(f"Zeeman Energy = {zeeman_energy.item():.6f}")
+
+                # log data
+                energy_history.append(energy.item())
+                magmom_history.append(magmom.detach().clone())
+                grad_norm_history.append(magmom.grad.norm().item())
+
                 return energy
 
+            # ----------------------------------
+            # LBFGS optimization step
+            # ----------------------------------
             optimizer.step(closure)
 
-            # Cache final magnetic moments
-            self.cache_magmom = magmom.detach()
+            # --------------------------------------------------------
+            # ENFORCE FIXED MAGNITUDE OF MAGMOM AFTER LBFGS UPDATE
+            # --------------------------------------------------------
+            if self.constrain_magnitude:
+                with torch.no_grad():
+                    mu = magmom
+                    norms = mu.norm(dim=1, keepdim=True) + 1e-12
+                    magmom[:] = self.original_magmom_magnitudes * (mu / norms)
 
-            # Final output (evaluate one last time with final magmom)
+
+            # update cache and data dict
+            self.cache_magmom = magmom.detach()
             data["dft_magmom"] = magmom
 
+        # if self.use_scf:
+        #     optimizer = torch.optim.LBFGS(
+        #         [magmom],
+        #         max_iter=self.n_scf_step,
+        #         tolerance_grad=self.scf_tol,
+        #         line_search_fn="strong_wolfe",
+        #         lr=self.scf_step_size,
+        #     )
+            
+        #     def closure():
+        #         optimizer.zero_grad()
+        #         data["magmom"] = magmom
+
+        #         output = self.magmom_mace(
+        #             data,
+        #             training=training,
+        #             compute_force=compute_force,
+        #             compute_virials=compute_virials,
+        #             compute_stress=compute_stress,
+        #             compute_displacement=compute_displacement,
+        #         )
+
+        #         energy = output["energy"][0]
+                
+        #         if self.constrain_magnitude:
+        #             raw_grad = -output["magforces"].detach()
+        #             mu = magmom
+        #             mu_norm = mu / (mu.norm(dim=1, keepdim=True) + 1e-12)  # unit vector
+        #             grad_proj = raw_grad - (raw_grad * mu_norm).sum(dim=1, keepdim=True) * mu_norm
+
+        #             magmom.grad = grad_proj
+
+        #             # Zeeman energy contribution: -μ·B
+        #             if applied_B_field is not None:
+        #                 zeeman_energy = -mu_B * (magmom * applied_B_field).sum()
+        #                 energy = energy + zeeman_energy
+                
+        #             # Magnetic forces = -∂E/∂μ
+        #             if applied_B_field is not None:
+        #                 z_grad = -mu_B * applied_B_field.detach()
+        #                 # project Zeeman gradient too
+        #                 z_grad_proj = z_grad - (z_grad * mu_norm).sum(dim=1, keepdim=True) * mu_norm
+        #                 magmom.grad += z_grad_proj
+        #         else:
+        #             # Zeeman energy contribution: -μ·B
+        #             if applied_B_field is not None:
+        #                 zeeman_energy = -mu_B * (magmom * applied_B_field).sum()
+        #                 energy = energy + zeeman_energy
+                
+        #             # Magnetic forces = -∂E/∂μ
+        #             magmom.grad = -output["magforces"].detach()
+        #             if applied_B_field is not None:
+        #                 magmom.grad += -mu_B * applied_B_field.detach()  # d(-μ·B)/dμ = -B
+
+        #         if self.scf_logging:
+        #             grad_norm = magmom.grad.norm().item()
+        #             print(f" ===== ")
+        #             print(f"[SCF LBFGS] Energy = {energy.item():.6f} | |Mag force| = {grad_norm:.6f}")
+        #             # print(f"1b magmom = {output['one_body_magmom_energy']}")
+        #             if applied_B_field is not None:
+        #                 print(f"Zeeman Energy = {zeeman_energy.item():.6f}")
+                    
+        #         # loggings
+        #         energy_history.append(energy.item())
+        #         magmom_history.append(magmom.detach().clone())
+        #         grad_norm_history.append(magmom.grad.norm().item())
+
+        #         return energy
+
+        #     optimizer.step(closure)
+        #     self.cache_magmom = magmom.detach()
+        #     data["dft_magmom"] = magmom
+
+        # === Final evaluation with equilibrated magmom ===
         final_output = self.magmom_mace(
             data,
             training=training,
@@ -3889,9 +4628,17 @@ class MagneticSCFMACE(torch.nn.Module):
             compute_displacement=compute_displacement,
         )
 
-        # Add SCF info to output
+        # Add Zeeman term in final energy
+        if applied_B_field is not None:
+            zeeman_energy = -mu_B * (magmom * applied_B_field).sum()
+            final_output["energy"] = final_output["energy"] + zeeman_energy
+
         final_output["scf_energy_history"] = torch.tensor(energy_history, dtype=torch.float32)
+        final_output["grad_norm_history"] = torch.tensor(grad_norm_history, dtype=torch.float32)
         final_output["scf_steps"] = len(energy_history)
         final_output["equilibrated_magmom"] = magmom.detach()
+        final_output["applied_field"] = applied_B_field
+        if self.return_magmom_hist:
+            final_output["magmom_history"] = torch.stack(magmom_history)
 
         return final_output

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -2139,6 +2139,240 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleSh
         }
         return output
 
+@compile_mode("script")
+class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(MagneticMACE):
+    def __init__(
+        self,
+        atomic_inter_scale: float,
+        atomic_inter_shift: float,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.scale_shift = ScaleShiftBlock(
+            scale=atomic_inter_scale, shift=0.0
+        )
+
+        # modify spherical to solid harmonics for magnetic moment
+        self.mag_solid_harmoics = SHModule(self.mag_spherical_harmonics._lmax)
+        self.mag_spherical_harmonics = None
+        self.magmom_readouts = None
+        self.magmom_products = None
+
+        self.onebody_magmombasis_list = torch.nn.ModuleList()
+
+        # coefficient for the chebyshev polynomails
+
+
+        # assume self.atomic_numbers is
+        # self.register_buffer(
+        #     "atomic_numbers", torch.tensor(atomic_numbers, dtype=torch.int64)
+        # )
+        
+        # initialize this coefficient for each species that one can 
+        # access later by an one hot embeeding of atomic numbers data["node_attrs"]
+        
+        # self.onebody_magmombasis_list = {
+        #     Z.item(): torch.nn.Parameter(torch.randn(10))
+        #     for Z in self.atomic_numbers
+        # }
+
+
+        self.onebody_magmombasis_coeffs = torch.nn.Parameter(torch.randn(len(self.atomic_numbers), 10, len(self.heads)))
+
+        self.one_body_cheb_basis_with_const = ChebychevBasisWithConst(
+            r_max = 1.0,
+            num_basis = 10,
+        )
+
+        # correction to shift E0s for each species
+        self.register_buffer(
+            "one_body_magmom_const_correction", torch.zeros(len(self.atomic_numbers), len(self.heads))
+        )
+
+    def forward(
+        self,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
+        compute_force: bool = True,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_hessian: bool = False,
+        compute_magforces: bool = True,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # Setup
+        data["positions"].requires_grad_(True)
+        data["node_attrs"].requires_grad_(True)
+        data["magmom"].requires_grad_(True)
+        
+        num_graphs = data["ptr"].numel() - 1
+        num_atoms_arange = torch.arange(data["positions"].shape[0])
+        node_heads = (
+            data["head"][data["batch"]]
+            if "head" in data
+            else torch.zeros_like(data["batch"])
+        )
+        displacement = torch.zeros(
+            (num_graphs, 3, 3),
+            dtype=data["positions"].dtype,
+            device=data["positions"].device,
+        )
+        if compute_virials or compute_stress or compute_displacement:
+            (
+                data["positions"],
+                data["shifts"],
+                displacement,
+            ) = get_symmetric_displacement(
+                positions=data["positions"],
+                unit_shifts=data["unit_shifts"],
+                cell=data["cell"],
+                edge_index=data["edge_index"],
+                num_graphs=num_graphs,
+                batch=data["batch"],
+            )
+
+        # Atomic energies
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])[
+            num_atoms_arange, node_heads
+        ]
+        e0 = scatter_sum(
+            src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
+        )  # [n_graphs, num_heads]
+
+        # node embedding on species
+        node_feats = self.node_embedding(data["node_attrs"])
+
+        # prepare the Rnl and Ylm
+        vectors, lengths = get_edge_vectors_and_lengths(
+            positions=data["positions"],
+            edge_index=data["edge_index"],
+            shifts=data["shifts"],
+        )
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+        if hasattr(self, "pair_repulsion"):
+            pair_node_energy = self.pair_repulsion_fn(
+                lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+            )
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+
+        # --- magnetic stuffs ---
+        
+        magmom_lenghts = torch.norm(data["magmom"], dim=-1, keepdim=True)
+        element_dependent_scaling = self.m_max[torch.argmax(data["node_attrs"], dim=1)].unsqueeze(-1)
+        element_dependent_scaling.requires_grad_(True)
+        element_dependent_scaling.retain_grad()
+        
+        magmom_lenghts_trans = 1 - 2 * (magmom_lenghts / element_dependent_scaling) ** 2
+        magmom_node_attrs = self.mag_solid_harmoics(data["magmom"])
+
+        #
+        magmom_node_feats = self.mag_radial_embedding(magmom_lenghts_trans) # (n_atoms, n_basis)
+
+        # one body contribution radials, this is with constant shift so that it can be fitted
+        magmom_one_body_radials = self.one_body_cheb_basis_with_const(
+            magmom_lenghts_trans
+        )
+        
+        # Interactions
+        node_es_list = [pair_node_energy]
+        node_feats_list = []
+        magmom_node_feats_list = []
+        for (idx, (interaction, product, readout)) in enumerate(zip(
+            self.interactions, self.products, self.readouts
+        )):
+            node_feats, sc = interaction(
+                node_attrs=data["node_attrs"],
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs
+            )
+          
+            node_feats = product(
+                node_feats=node_feats, sc=sc,node_attrs=data["node_attrs"], 
+                magmom_node_inv_feats=magmom_node_feats,
+                magmom_node_attrs=magmom_node_attrs,
+            )
+            
+            node_feats_list.append(node_feats)
+            if idx == (len(self.readouts) - 1):    
+                # linear (natom, num_basis) -> (natom, 1)
+                # remove certain constant to make it matches with E0, 
+                # self.one_body_magmom_const_correction is computed outside after pre-training
+                # Select the correct coefficient row for each atom via einsum
+                selected_coeffs = torch.einsum(
+                    "ns,sbh->nbh", data["node_attrs"], self.onebody_magmombasis_coeffs
+                )
+                #
+                one_body_correction = torch.einsum(
+                    'ns,sh->nh', data["node_attrs"], self.one_body_magmom_const_correction
+                )
+                # Compute dot product over nbasis → (n_nodes, num_heads)
+                onebody_magmom_contri = (magmom_one_body_radials.unsqueeze(-1) * selected_coeffs).sum(dim=1)
+
+                # apply correction so that the zero matches E0 exactly
+                onebody_magmom_contri -= one_body_correction
+
+                # Gather energy per atom + one-body magmom contribution for each head
+                node_es_list.append(
+                    readout(node_feats, node_heads)[num_atoms_arange, node_heads] +
+                    onebody_magmom_contri[num_atoms_arange, node_heads]
+                )
+            else:
+                node_es_list.append(
+                    readout(node_feats, node_heads)[num_atoms_arange, node_heads]
+                )  # {[n_nodes, ], }
+
+
+        # Concatenate node features
+        node_feats_out = torch.cat(node_feats_list, dim=-1) 
+
+        # Sum over interactions
+        node_inter_es = torch.sum(
+            torch.stack(node_es_list, dim=0), dim=0
+        )  # [n_nodes, ]
+        node_inter_es = self.scale_shift(node_inter_es, node_heads)
+
+        # Sum over nodes in graph
+        inter_e = scatter_sum(
+            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+        
+        # Add E_0 and (scaled) interaction energy
+        total_energy = e0 + inter_e
+        node_energy = node_e0 + node_inter_es
+        forces, virials, stress, hessian, magforces = get_outputs(
+            energy=inter_e,
+            positions=data["positions"],
+            displacement=displacement,
+            cell=data["cell"],
+            magmoms=data["magmom"],
+            training=training,
+            compute_force=compute_force,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_hessian=compute_hessian,
+            compute_magforces=compute_magforces,
+        )
+        output = {
+            "energy": total_energy,
+            "node_energy": node_energy,
+            "interaction_energy": inter_e,
+            "forces": forces,
+            "magforces": magforces,
+            "virials": virials,
+            "stress": stress,
+            "hessian": hessian,
+            "displacement": displacement,
+            "node_feats": node_feats_out,
+        }
+        return output
 
 @compile_mode("script")
 class MagneticSolidHarmonicsFlexibleSOScaleShiftMACE(MagneticMACE):

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -2147,6 +2147,7 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfM
         atomic_inter_shift: float,
         **kwargs,
     ):
+        num_mag_radial_basis_one_body = kwargs.pop("num_mag_radial_basis_one_body")
         super().__init__(**kwargs)
         self.scale_shift = ScaleShiftBlock(
             scale=atomic_inter_scale, shift=0.0
@@ -2161,27 +2162,11 @@ class MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfM
         self.onebody_magmombasis_list = torch.nn.ModuleList()
 
         # coefficient for the chebyshev polynomails
-
-
-        # assume self.atomic_numbers is
-        # self.register_buffer(
-        #     "atomic_numbers", torch.tensor(atomic_numbers, dtype=torch.int64)
-        # )
-        
-        # initialize this coefficient for each species that one can 
-        # access later by an one hot embeeding of atomic numbers data["node_attrs"]
-        
-        # self.onebody_magmombasis_list = {
-        #     Z.item(): torch.nn.Parameter(torch.randn(10))
-        #     for Z in self.atomic_numbers
-        # }
-
-
-        self.onebody_magmombasis_coeffs = torch.nn.Parameter(torch.randn(len(self.atomic_numbers), 10, len(self.heads)))
+        self.onebody_magmombasis_coeffs = torch.nn.Parameter(torch.randn(len(self.atomic_numbers), num_mag_radial_basis_one_body, len(self.heads)))
 
         self.one_body_cheb_basis_with_const = ChebychevBasisWithConst(
             r_max = 1.0,
-            num_basis = 10,
+            num_basis = num_mag_radial_basis_one_body,
         )
 
         # correction to shift E0s for each species

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -5069,17 +5069,20 @@ class MagneticSCFMACE(torch.nn.Module):
         model,
         n_scf_step=10,
         scf_tol=1e-5,
+        scf_tol_diff=1e-9,
         scf_logging=False,
         scf_step_size=1.0,
         use_scf=True,
         return_magmom_hist=False,
         constrain_magnitude=False,
         use_collinear=False,
+        mask_ats=None
     ):
         super().__init__()
         self.magmom_mace = model
         self.n_scf_step = n_scf_step
         self.scf_tol = scf_tol
+        self.scf_tol_diff = scf_tol_diff
         self.scf_logging = scf_logging
         self.scf_step_size = scf_step_size
         self.use_scf = use_scf
@@ -5087,6 +5090,7 @@ class MagneticSCFMACE(torch.nn.Module):
         self.constrain_magnitude = constrain_magnitude
         self.use_collinear = use_collinear
         self.cache_magmom = None
+        self.mask_ats = mask_ats
 
     def forward(
         self,
@@ -5113,8 +5117,10 @@ class MagneticSCFMACE(torch.nn.Module):
         magmom.requires_grad_(True)
         energy_history = []
         grad_norm_history = []
-        scf_iter = []
+        grad_history = []
         magmom_history = []
+        grad_inf_history = []
+        step_inf_history = []
         # === Prepare applied magnetic field ===
         if applied_B_field is not None:
             applied_B_field = applied_B_field.to(device)
@@ -5134,6 +5140,7 @@ class MagneticSCFMACE(torch.nn.Module):
                 [magmom],
                 max_iter=self.n_scf_step,
                 tolerance_grad=self.scf_tol,
+                tolerance_change=self.scf_tol_diff,
                 line_search_fn="strong_wolfe",
                 lr=self.scf_step_size,
             )
@@ -5189,9 +5196,20 @@ class MagneticSCFMACE(torch.nn.Module):
                 # if grad_norm > max_grad_norm:
                 #     raw_grad = raw_grad * (max_grad_norm / (grad_norm + 1e-12))
                 # after computing raw_grad
+                # ==== a bunch of constrains =====
                 if self.use_collinear:
                     raw_grad[:, 0] = 0.0
                     raw_grad[:, 1] = 0.0
+                # ----------------------------------
+                # Freeze magnetic moments for masked atoms
+                # ----------------------------------
+                if self.mask_ats is not None:
+                    if isinstance(self.mask_ats, (list, tuple)):
+                        raw_grad[self.mask_ats] = 0.0
+                    else:
+                        # assume boolean mask of shape (N,)
+                        raw_grad[self.mask_ats] = 0.0
+
                 # assign gradient manually
                 magmom.grad = raw_grad
 
@@ -5202,17 +5220,37 @@ class MagneticSCFMACE(torch.nn.Module):
                     if applied_B_field is not None:
                         print(f"Zeeman Energy = {zeeman_energy.item():.6f}")
 
+                # flat gradient used by LBFGS
+                flat_grad = optimizer._gather_flat_grad()
+                grad_inf = flat_grad.abs().max().item()
+
+                # LBFGS step direction and step size
+                state = optimizer.state[magmom]
+                d = state.get("d")
+                t = state.get("t")
+
+                if d is not None and t is not None:
+                    step_inf = (t * d).abs().max().item()
+                else:
+                    step_inf = np.nan
+
+
                 # log data
-                energy_history.append(energy.item())
+                energy_history.append(energy.clone().item())
                 magmom_history.append(magmom.detach().clone())
                 grad_norm_history.append(magmom.grad.norm().item())
-
+                grad_history.append(magmom.grad.detach().clone())
+                grad_inf_history.append(grad_inf)
+                step_inf_history.append(step_inf)
                 return energy
 
             # ----------------------------------
             # LBFGS optimization step
             # ----------------------------------
             optimizer.step(closure)
+            # if self.mask_ats is not None:
+            #     with torch.no_grad():
+            #         magmom[self.mask_ats] = self.cache_magmom[self.mask_ats]
 
             # --------------------------------------------------------
             # ENFORCE FIXED MAGNITUDE OF MAGMOM AFTER LBFGS UPDATE
@@ -5315,12 +5353,16 @@ class MagneticSCFMACE(torch.nn.Module):
         if applied_B_field is not None:
             zeeman_energy = -mu_B * (magmom * applied_B_field).sum()
             final_output["energy"] = final_output["energy"] + zeeman_energy
-
         final_output["scf_energy_history"] = torch.tensor(energy_history, dtype=torch.float64)
         final_output["grad_norm_history"] = torch.tensor(grad_norm_history, dtype=torch.float64)
         final_output["scf_steps"] = len(energy_history)
         final_output["equilibrated_magmom"] = magmom.detach()
         final_output["applied_field"] = applied_B_field
+        if self.use_scf:
+            final_output["grad_history"] = torch.stack(grad_history)
+            final_output["grad_inf_history"] = torch.tensor(grad_inf_history)
+            final_output["step_inf_history"] = torch.tensor(step_inf_history)
+
         if self.return_magmom_hist:
             final_output["magmom_history"] = torch.stack(magmom_history)
 

--- a/mace/modules/radial.py
+++ b/mace/modules/radial.py
@@ -83,9 +83,9 @@ class ChebychevBasis(torch.nn.Module):
         return (
             f"{self.__class__.__name__}(r_max={self.r_max}, num_basis={self.num_basis},"
         )
-        
+
 @compile_mode("script")
-class ChebychevBasis2(nn.Module):
+class ChebychevBasis2(torch.nn.Module):
     """
     Fully differentiable Chebyshev basis (T_n) using recurrence.
     Matches behavior of torch.special.chebyshev_polynomial_t(x, n) in shape and interface.

--- a/mace/modules/symmetric_contraction.py
+++ b/mace/modules/symmetric_contraction.py
@@ -13,11 +13,180 @@ import torch.fx
 from e3nn import o3
 from e3nn.util.codegen import CodeGenMixin
 from e3nn.util.jit import compile_mode
+from opt_einsum import contract
 
 from mace.tools.cg import U_matrix_real
 
 BATCH_EXAMPLE = 10
-ALPHABET = ["w", "x", "v", "n", "z", "r", "t", "y", "u", "o", "p", "s"]
+ALPHABET = ["w", "x", "v", "n", "z", "r", "t"]
+ALPHABET_MAGMOM = ["y", "u", "o", "p", "s"] # ["w", "x", "v", "n", "z", "r", "t", "y", "u", "o", "p", "s"]
+
+
+@compile_mode("script")
+class NonSOCSymmetricContraction(CodeGenMixin, torch.nn.Module):
+    def __init__(
+        self,
+        irreps_in: o3.Irreps,
+        irreps_out: o3.Irreps,
+        correlation: Union[int, Dict[str, int]],
+        irrep_normalization: str = "component",
+        path_normalization: str = "element",
+        internal_weights: Optional[bool] = None,
+        shared_weights: Optional[bool] = None,
+        num_elements: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+
+        if irrep_normalization is None:
+            irrep_normalization = "component"
+
+        if path_normalization is None:
+            path_normalization = "element"
+
+        assert irrep_normalization in ["component", "norm", "none"]
+        assert path_normalization in ["element", "path", "none"]
+
+        self.irreps_in = o3.Irreps(irreps_in)
+        self.irreps_out = o3.Irreps(irreps_out)
+
+        del irreps_in, irreps_out
+
+        if not isinstance(correlation, tuple):
+            corr = correlation
+            correlation = {}
+            for irrep_out in self.irreps_out:
+                correlation[irrep_out] = corr
+
+        assert shared_weights or not internal_weights
+
+        if internal_weights is None:
+            internal_weights = True
+
+        self.internal_weights = internal_weights
+        self.shared_weights = shared_weights
+
+        del internal_weights, shared_weights
+
+        self.contractions = torch.nn.ModuleList()
+        # import pdb; pdb.set_trace();
+        for irrep_out in self.irreps_out:
+            self.contractions.append(
+                NonSOCContraction(
+                    irreps_in=self.irreps_in,
+                    irrep_out=o3.Irreps(str(irrep_out.ir)),
+                    correlation=correlation[irrep_out],
+                    internal_weights=self.internal_weights,
+                    num_elements=num_elements,
+                    weights=self.shared_weights,
+                )
+            )
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
+        outs = [contraction(x, y) for contraction in self.contractions]
+        return torch.cat(outs, dim=-1)
+    
+@compile_mode("script")
+class NonSOCContraction(torch.nn.Module):
+    def __init__(
+        self,
+        irreps_in: o3.Irreps,
+        irrep_out: o3.Irreps,
+        correlation: int,
+        internal_weights: bool = True,
+        num_elements: Optional[int] = None,
+        weights: Optional[torch.Tensor] = None,
+    ) -> None:
+        super().__init__()
+
+        self.num_features = irreps_in.count((0, 1))
+        self.coupling_irreps = o3.Irreps([irrep.ir for irrep in irreps_in])
+        self.correlation = correlation
+        self.irrep_out = irrep_out
+        
+        dtype = torch.get_default_dtype()
+        for nu in range(1, correlation + 1):
+            U_matrix = U_matrix_real(
+                irreps_in=self.coupling_irreps,
+                irreps_out=irrep_out,
+                correlation=nu,
+                dtype=dtype,
+            )[-1]
+            self.register_buffer(f"U_matrix_{nu}", U_matrix)
+
+        # assume the input is always m_ell = 1
+        for nu in range(1, correlation + 1):
+            U_matrix = U_matrix_real(
+                irreps_in=o3.Irreps('1x0e+1x1o'), #self.coupling_irreps,
+                irreps_out=irrep_out,
+                correlation=nu,
+                dtype=dtype,
+            )[-1]
+            self.register_buffer(f"U_matrix_magmom_{nu}", U_matrix)
+
+        # Tensor contraction equations
+        self.contractions_weighting = torch.nn.ModuleList()
+        self.contractions_features = torch.nn.ModuleList()
+
+        # Create weight for product basis
+        self.weights = torch.nn.ParameterList([])
+
+        for i in range(correlation, 0, -1):
+            # Shapes definying
+            num_params = self.U_tensors(i).size()[-1]
+            num_params_magmom = self.U_magmom_tensors(i).size()[-1]
+            num_equivariance = 2 * irrep_out.lmax + 1
+            num_ell = self.U_tensors(i).size()[-2]
+
+            if i == correlation:
+                # Parameters for the product basis
+                w = torch.nn.Parameter(
+                    torch.randn((num_elements, num_params, num_params_magmom, self.num_features))
+                    / (num_params * num_params_magmom)
+                )
+                self.weights_max = w
+            else:
+                # Parameters for the product basis
+                w = torch.nn.Parameter(
+                    torch.randn((num_elements, num_params, num_params_magmom, self.num_features))
+                    / (num_params * num_params_magmom)
+                )
+                self.weights.append(w)
+        if not internal_weights:
+            self.weights = weights[:-1]
+            self.weights_max = weights[-1]
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
+        # x is of shape A_{i, k, lm, l'm'}
+        # 'cg_r, cg_m, A_{k, lm, l',m}
+
+        assert self.irrep_out.lmax == 0
+        bs = x.shape[0]
+        outs_dict = dict()
+
+        parse_instruction_1 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)]+ ["ik,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)]+ ["lq,"]+ ["ekqa,bail,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
+
+        parse_instruction_2 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["ijk,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["lmq,"] + ["ekqa,bail,bajm,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
+        parse_instruction_3 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["ijfk,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["lmgq,"] + ["ekqa,bail,bajm,bafg,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
+        parse_instruction_list = ["".join(parse_instruction_1), "".join(parse_instruction_2), "".join(parse_instruction_3)]
+        
+        for nu in range(1, self.correlation+1):
+            if nu == 1:
+                outs_dict[nu] = contract(parse_instruction_list[nu-1], self.U_tensors(nu), self.U_magmom_tensors(nu), self.weights[nu-1], x, y)
+            elif nu == 2:
+                outs_dict[nu] = contract(parse_instruction_list[nu-1], self.U_tensors(nu), self.U_magmom_tensors(nu), self.weights[nu-1], x, x, y)
+            elif nu == 3:
+                outs_dict[nu] = contract(parse_instruction_list[nu-1], self.U_tensors(nu), self.U_magmom_tensors(nu), self.weights_max, x, x, x, y)
+        
+        out = outs_dict[self.correlation]
+        for nu in range(self.correlation - 1, 0, -1):
+            out += outs_dict[nu]
+        return out.view(out.shape[0], -1)
+
+    def U_tensors(self, nu: int):
+        return dict(self.named_buffers())[f"U_matrix_{nu}"]
+    
+    def U_magmom_tensors(self, nu: int):
+        return dict(self.named_buffers())[f"U_matrix_magmom_{nu}"]
 
 
 @compile_mode("script")

--- a/mace/modules/symmetric_contraction.py
+++ b/mace/modules/symmetric_contraction.py
@@ -7,6 +7,7 @@
 
 from typing import Dict, Optional, Union
 
+import logging
 import opt_einsum_fx
 import torch
 import torch.fx
@@ -17,12 +18,28 @@ from opt_einsum import contract
 
 from mace.tools.cg import U_matrix_real
 
+
+try:
+    import cuequivariance as cue
+
+    CUET_AVAILABLE = True
+except ImportError:
+    CUET_AVAILABLE = False
+
 BATCH_EXAMPLE = 10
 ALPHABET = ["w", "x", "v", "n", "z", "r", "t"]
 ALPHABET_MAGMOM = ["y", "u", "o", "p", "s"] # ["w", "x", "v", "n", "z", "r", "t", "y", "u", "o", "p", "s"]
+NONSOC_CONTRACTION_EQUATIONS = {
+    1: "ik,lq,ekqa,bail,be->ba",
+    2: "ijk,lmq,ekqa,bail,bajm,be->ba",
+    3: "ijfk,lmgq,ekqa,bail,bajm,bafg,be->ba",
+}
 
 
-@compile_mode("script")
+LOGGER = logging.getLogger(__name__)
+
+
+# @compile_mode("script")
 class NonSOCSymmetricContraction(CodeGenMixin, torch.nn.Module):
     def __init__(
         self,
@@ -34,6 +51,7 @@ class NonSOCSymmetricContraction(CodeGenMixin, torch.nn.Module):
         internal_weights: Optional[bool] = None,
         shared_weights: Optional[bool] = None,
         num_elements: Optional[int] = None,
+        magmom_irreps: Optional[o3.Irreps] = None,
     ) -> None:
         super().__init__()
 
@@ -48,6 +66,11 @@ class NonSOCSymmetricContraction(CodeGenMixin, torch.nn.Module):
 
         self.irreps_in = o3.Irreps(irreps_in)
         self.irreps_out = o3.Irreps(irreps_out)
+        self.magmom_irreps = (
+            o3.Irreps(magmom_irreps)
+            if magmom_irreps is not None
+            else o3.Irreps('1x0e+1x1o')
+        )
 
         del irreps_in, irreps_out
 
@@ -78,6 +101,7 @@ class NonSOCSymmetricContraction(CodeGenMixin, torch.nn.Module):
                     internal_weights=self.internal_weights,
                     num_elements=num_elements,
                     weights=self.shared_weights,
+                    magmom_irreps=self.magmom_irreps,
                 )
             )
 
@@ -85,7 +109,226 @@ class NonSOCSymmetricContraction(CodeGenMixin, torch.nn.Module):
         outs = [contraction(x, y) for contraction in self.contractions]
         return torch.cat(outs, dim=-1)
     
-@compile_mode("script")
+# @compile_mode("script")
+# class NonSOCContraction(torch.nn.Module):
+#     def __init__(
+#         self,
+#         irreps_in: o3.Irreps,
+#         irrep_out: o3.Irreps,
+#         correlation: int,
+#         internal_weights: bool = True,
+#         num_elements: Optional[int] = None,
+#         weights: Optional[torch.Tensor] = None,
+#         magmom_irreps: Optional[o3.Irreps] = None,
+#     ) -> None:
+#         super().__init__()
+
+#         if num_elements is None:
+#             raise ValueError("num_elements must be provided for NonSOCContraction")
+#         if correlation < 1 or correlation > 3:
+#             raise ValueError(
+#                 f"NonSOCContraction currently supports correlation in [1, 3], got {correlation}"
+#             )
+
+#         # In this non-SOC path, channel index 'a' is multiplicity axis.
+#         muls = [mul for mul, _ in irreps_in]
+#         if len(set(muls)) != 1:
+#             raise ValueError(
+#                 f"NonSOCContraction expects uniform multiplicity in irreps_in; got muls={muls}"
+#             )
+#         self.num_features = int(muls[0])
+
+#         self.coupling_irreps = o3.Irreps([ir.ir for ir in irreps_in])
+#         magmom_irreps_full = (
+#             o3.Irreps(magmom_irreps)
+#             if magmom_irreps is not None
+#             else o3.Irreps("1x0e+1x1o")
+#         )
+#         # Match standard contraction behavior: CG basis on irrep types (not multiplicity).
+#         self.coupling_irreps_magmom = o3.Irreps([ir.ir for ir in magmom_irreps_full])
+
+#         self.correlation = correlation
+#         self.irrep_out = irrep_out
+
+#         assert CUET_AVAILABLE, "cuequivariance library is required but not available."
+#         dtype = torch.get_default_dtype()
+
+#         # Build CG basis buffers
+#         for nu in range(1, correlation + 1):
+#             U = U_matrix_real(
+#                 irreps_in=self.coupling_irreps,
+#                 irreps_out=irrep_out,
+#                 correlation=nu,
+#                 dtype=dtype,
+#                 use_cueq_cg=True,
+#             )[-1]
+#             self.register_buffer(f"U_matrix_{nu}", U)
+
+#         for nu in range(1, correlation + 1):
+#             Um = U_matrix_real(
+#                 irreps_in=self.coupling_irreps_magmom,
+#                 irreps_out=irrep_out,
+#                 correlation=nu,
+#                 dtype=dtype,
+#                 use_cueq_cg=True,
+#             )[-1]
+#             self.register_buffer(f"U_matrix_magmom_{nu}", Um)
+
+#         # Recursive contraction modules, mirroring Contraction class design.
+#         self.contractions_weighting = torch.nn.ModuleList()
+#         self.contractions_features = torch.nn.ModuleList()
+#         self.weights = torch.nn.ParameterList([])
+
+#         # Build from high->low, as Contraction does.
+#         for i in range(correlation, 0, -1):
+#             num_params = int(self.U_tensors(i).size(-1))
+#             num_params_magmom = int(self.U_magmom_tensors(i).size(-1))
+#             num_equivariance = 2 * irrep_out.lmax + 1
+#             num_ell_r = int(self.U_tensors(i).size(-2))
+#             num_ell_m = int(self.U_magmom_tensors(i).size(-2))
+
+#             if i == correlation:
+#                 parse_subscript_main = (
+#                     [ALPHABET[j] for j in range(i + min(irrep_out.lmax, 1) - 1)]
+#                     + ["ik,"] +
+#                     [ALPHABET_MAGMOM[j] for j in range(i + min(irrep_out.lmax, 1) - 1)]
+#                     + ["iq,ekqc,bci,be -> bc"]
+#                     + [ALPHABET[j] for j in range(i + min(irrep_out.lmax, 1) - 1)]
+#                     + [ALPHABET_MAGMOM[j] for j in range(i + min(irrep_out.lmax, 1) - 1)]
+#                 )
+#                 graph_module_main = torch.fx.symbolic_trace(
+#                     lambda x, y, p, w, z: torch.einsum(
+#                         "".join(parse_subscript_main), x, y, p, w, z
+#                     )
+#                 )
+
+#                 # Optimizing the contractions
+#                 self.graph_opt_main = opt_einsum_fx.optimize_einsums_full(
+#                     model=graph_module_main,
+#                     example_inputs=(
+#                         torch.randn(
+#                             [num_equivariance] + [num_ell_r] * i + [num_equivariance] + [num_ell_m] * i+ [num_params]
+#                         ).squeeze(0),
+#                         torch.randn(
+#                             [num_equivariance] + [num_ell_m] * i + [num_equivariance] + [num_ell_m] * i+ [num_params]
+#                         ).squeeze(0),
+#                         torch.randn((num_elements, num_params, self.num_features)),
+#                         torch.randn((BATCH_EXAMPLE, self.num_features, num_ell_r, num_ell_m)),
+#                         torch.randn((BATCH_EXAMPLE, num_elements)),
+#                     ),
+#                 )
+
+#                 self.weights_max = torch.nn.Parameter(
+#                     torch.randn((num_elements, num_params, num_params_magmom, self.num_features), dtype=dtype)
+#                     / (num_params * num_params_magmom)
+#                 )
+#             else:
+#                 # Lower-order recursive updates:
+#                 # c = contract_weights(U_i, Um_i, w_i, y)
+#                 # out = contract_features(c + out, x)
+#                 if i == 1:
+#                     eq_w = "ik,lq,ekqa,be->bail"
+#                     eq_f = "bail,bail->ba"
+#                     ex_u_shape = (num_equivariance, num_ell_r, num_params)
+#                     ex_um_shape = (num_equivariance, num_ell_m, num_params_magmom)
+#                     ex_c_shape = (BATCH_EXAMPLE, self.num_features, num_ell_r, num_ell_m)
+#                     ex_x_shape = (BATCH_EXAMPLE, self.num_features, num_ell_r, num_ell_m)
+#                 else:  # i == 2
+#                     eq_w = "ijk,lmq,ekqa,be->bajm"
+#                     eq_f = "bajm,bail->ba"
+#                     ex_u_shape = (num_equivariance, num_ell_r, num_ell_r, num_params)
+#                     ex_um_shape = (num_equivariance, num_ell_m, num_ell_m, num_params_magmom)
+#                     ex_c_shape = (BATCH_EXAMPLE, self.num_features, num_ell_r, num_ell_m)
+#                     ex_x_shape = (BATCH_EXAMPLE, self.num_features, num_ell_r, num_ell_m)
+
+#                 # graph_module_weighting = torch.fx.symbolic_trace(
+#                 #     lambda u, um, w, y, eq_w=eq_w: torch.einsum(eq_w, u, um, w, y)
+#                 # )
+#                 # graph_module_features = torch.fx.symbolic_trace(
+#                 #     lambda c, x, eq_f=eq_f: torch.einsum(eq_f, c, x)
+#                 # )
+#                 if i == 1:
+#                     graph_module_weighting = torch.fx.symbolic_trace(
+#                         lambda u, um, w, y: torch.einsum("ik,lq,ekqa,be->bail", u, um, w, y)
+#                     )
+#                     graph_module_features = torch.fx.symbolic_trace(
+#                         lambda c, x: torch.einsum("bail,bail->ba", c, x)
+#                     )
+#                 else:  # i == 2
+#                     graph_module_weighting = torch.fx.symbolic_trace(
+#                         lambda u, um, w, y: torch.einsum("ijk,lmq,ekqa,be->bajm", u, um, w, y)
+#                     )
+#                     graph_module_features = torch.fx.symbolic_trace(
+#                         lambda c, x: torch.einsum("bajm,bail->ba", c, x)
+#                     )
+
+
+#                 graph_opt_weighting = opt_einsum_fx.optimize_einsums_full(
+#                     model=graph_module_weighting,
+#                     example_inputs=(
+#                         torch.randn(ex_u_shape, dtype=dtype).squeeze(0),
+#                         torch.randn(ex_um_shape, dtype=dtype).squeeze(0),
+#                         torch.randn((num_elements, num_params, num_params_magmom, self.num_features), dtype=dtype),
+#                         torch.randn((BATCH_EXAMPLE, num_elements), dtype=dtype),
+#                     ),
+#                 )
+#                 graph_opt_features = opt_einsum_fx.optimize_einsums_full(
+#                     model=graph_module_features,
+#                     example_inputs=(
+#                         torch.randn(ex_c_shape, dtype=dtype),
+#                         torch.randn(ex_x_shape, dtype=dtype),
+#                     ),
+#                 )
+
+#                 self.contractions_weighting.append(graph_opt_weighting)
+#                 self.contractions_features.append(graph_opt_features)
+
+#                 w = torch.nn.Parameter(
+#                     torch.randn((num_elements, num_params, num_params_magmom, self.num_features), dtype=dtype)
+#                     / (num_params * num_params_magmom)
+#                 )
+#                 self.weights.append(w)
+
+#         if not internal_weights:
+#             self.weights = weights[:-1]
+#             self.weights_max = weights[-1]
+
+#     def forward(self, x: torch.Tensor, y: torch.Tensor):
+#         assert self.irrep_out.lmax == 0
+
+#         # Main term with fixed signature (U, U_mag, W, x, y)
+#         out = self.graph_opt_main(
+#             self.U_tensors(self.correlation),
+#             self.U_magmom_tensors(self.correlation),
+#             self.weights_max,
+#             x,
+#             y,
+#         )
+
+#         # Recursive lower-order corrections, matching Contraction.forward pattern.
+#         for i, (weight, contract_weights, contract_features) in enumerate(
+#             zip(self.weights, self.contractions_weighting, self.contractions_features)
+#         ):
+#             nu = self.correlation - i - 1
+#             c_tensor = contract_weights(
+#                 self.U_tensors(nu),
+#                 self.U_magmom_tensors(nu),
+#                 weight,
+#                 y,
+#             )
+#             c_tensor = c_tensor + out
+#             out = contract_features(c_tensor, x)
+
+#         return out.view(out.shape[0], -1)
+
+#     def U_tensors(self, nu: int):
+#         return dict(self.named_buffers())[f"U_matrix_{nu}"]
+
+#     def U_magmom_tensors(self, nu: int):
+#         return dict(self.named_buffers())[f"U_matrix_magmom_{nu}"]
+
+
+# @compile_mode("script")
 class NonSOCContraction(torch.nn.Module):
     def __init__(
         self,
@@ -95,31 +338,81 @@ class NonSOCContraction(torch.nn.Module):
         internal_weights: bool = True,
         num_elements: Optional[int] = None,
         weights: Optional[torch.Tensor] = None,
+        magmom_irreps: Optional[o3.Irreps] = None,
     ) -> None:
         super().__init__()
 
-        self.num_features = irreps_in.count((0, 1))
+        # In the non-SOC A-tensor path, einsum index 'a' is the channel multiplicity
+        # (mul axis after reshape), not total irreps count.
+        muls = [mul for mul, _ in irreps_in]
+        if len(set(muls)) != 1:
+            raise ValueError(
+                f"NonSOCContraction expects uniform multiplicity in irreps_in for channel axis; got muls={muls}"
+            )
+        self.num_features = int(muls[0])
         self.coupling_irreps = o3.Irreps([irrep.ir for irrep in irreps_in])
+        magmom_irreps_full = (
+            o3.Irreps(magmom_irreps)
+            if magmom_irreps is not None
+            else o3.Irreps('1x0e+1x1o')
+        )
+        # Match standard MACE contraction behavior: construct CG basis on irreps types,
+        # not multiplicities, to keep contraction basis dimensions consistent.
+        self.coupling_irreps_magmom = o3.Irreps([irrep.ir for irrep in magmom_irreps_full])
         self.correlation = correlation
         self.irrep_out = irrep_out
+        assert CUET_AVAILABLE, "cuequivariance library is required but not available."
         
         dtype = torch.get_default_dtype()
+        LOGGER.info(
+            "[NonSOCContraction] Building CG basis (structure): irreps_in=%s irreps_out=%s max_correlation=%s dtype=%s",
+            self.coupling_irreps,
+            irrep_out,
+            correlation,
+            dtype,
+        )
         for nu in range(1, correlation + 1):
+            LOGGER.info(
+                "[NonSOCContraction] U_matrix_%s with irreps_in=%s irreps_out=%s correlation=%s dtype=%s",
+                nu,
+                self.coupling_irreps,
+                irrep_out,
+                nu,
+                dtype,
+            )
             U_matrix = U_matrix_real(
                 irreps_in=self.coupling_irreps,
                 irreps_out=irrep_out,
                 correlation=nu,
                 dtype=dtype,
+                use_cueq_cg=True
             )[-1]
             self.register_buffer(f"U_matrix_{nu}", U_matrix)
 
-        # assume the input is always m_ell = 1
+        # Magmom coupling basis is configurable and should match the magmom-side
+        # irreps used to build the non-SOC interaction tensor.
+        LOGGER.info(
+            "[NonSOCContraction] Building CG basis (magmom): irreps_in=%s irreps_out=%s max_correlation=%s dtype=%s",
+            self.coupling_irreps_magmom,
+            irrep_out,
+            correlation,
+            dtype,
+        )
         for nu in range(1, correlation + 1):
+            LOGGER.info(
+                "[NonSOCContraction] U_matrix_magmom_%s with irreps_in=%s irreps_out=%s correlation=%s dtype=%s",
+                nu,
+                self.coupling_irreps_magmom,
+                irrep_out,
+                nu,
+                dtype,
+            )
             U_matrix = U_matrix_real(
-                irreps_in=o3.Irreps('1x0e+1x1o'), #self.coupling_irreps,
+                irreps_in=self.coupling_irreps_magmom,
                 irreps_out=irrep_out,
                 correlation=nu,
                 dtype=dtype,
+                use_cueq_cg=True
             )[-1]
             self.register_buffer(f"U_matrix_magmom_{nu}", U_matrix)
 
@@ -129,6 +422,7 @@ class NonSOCContraction(torch.nn.Module):
 
         # Create weight for product basis
         self.weights = torch.nn.ParameterList([])
+        lower_order_weights = []
 
         for i in range(correlation, 0, -1):
             # Shapes definying
@@ -145,48 +439,375 @@ class NonSOCContraction(torch.nn.Module):
                 )
                 self.weights_max = w
             else:
-                # Parameters for the product basis
+                # Parameters for lower-order product basis terms.
+                # Keep list ordered by nu ascending: weights[0] -> nu=1, weights[1] -> nu=2, ...
                 w = torch.nn.Parameter(
                     torch.randn((num_elements, num_params, num_params_magmom, self.num_features))
                     / (num_params * num_params_magmom)
                 )
-                self.weights.append(w)
+                lower_order_weights.append(w)
+        # Rebuild in ascending nu order: weights[0] -> nu=1, weights[1] -> nu=2, ...
+        if len(lower_order_weights) > 0:
+            self.weights = torch.nn.ParameterList(list(reversed(lower_order_weights)))
+
         if not internal_weights:
             self.weights = weights[:-1]
             self.weights_max = weights[-1]
 
-    def forward(self, x: torch.Tensor, y: torch.Tensor):
+        self._ensure_optimized_contractions()
+        self._ensure_sparse_paths()
+
+    # def sparse_contract_nu2(self, U_paths, U_mag_paths, weight, x, y):
+    #     idx_U, val_U = U_paths
+    #     idx_M, val_M = U_mag_paths
+
+    #     B = x.shape[0]
+    #     out = torch.zeros(B, weight.shape[-1], device=x.device)
+
+    #     for i in range(len(val_U)):
+    #         # indices from U
+    #         a, b, k = idx_U[i]   # adapt if ordering differs
+    #         w_u = val_U[i]
+
+    #         for j in range(len(val_M)):
+    #             l, m, q = idx_M[j]
+    #             w_m = val_M[j]
+
+    #             # combine weights
+    #             w_total = w_u * w_m
+
+    #             # contraction (YOU MUST VERIFY INDEX MATCHING)
+    #             term = (
+    #                 w_total
+    #                 * x[:, a]       # first x
+    #                 * x[:, b]       # second x
+    #                 * y[:, q]       # magmom
+    #             )
+
+    #             # apply learnable weight
+    #             term = term.unsqueeze(-1) * weight[:, k, q, :]
+
+    #             out += term.sum(dim=1)
+
+    #     return out
+
+    def _build_optimized_contraction(self, nu: int) -> torch.nn.Module:
+        dtype = self.weights_max.dtype
+        device = self.weights_max.device
+        u = self.U_tensors(nu)
+        um = self.U_magmom_tensors(nu)
+        weight = self.weights_max if nu == self.correlation else self.weights[nu - 1]
+        num_ell_r = int(self.U_tensors(1).size(-2))
+        num_ell_m = int(self.U_magmom_tensors(1).size(-2))
+        x_example = torch.randn(
+            (BATCH_EXAMPLE, self.num_features, num_ell_r, num_ell_m),
+            dtype=dtype,
+            device=device,
+        )
+        y_example = torch.randn(
+            (BATCH_EXAMPLE, weight.shape[0]),
+            dtype=dtype,
+            device=device,
+        )
+
+        if nu == 1:
+            graph_module = torch.fx.symbolic_trace(
+                lambda u_t, um_t, w_t, x_t, y_t: torch.einsum(
+                    NONSOC_CONTRACTION_EQUATIONS[1], u_t, um_t, w_t, x_t, y_t
+                )
+            )
+            example_inputs = (
+                torch.randn(tuple(u.shape), dtype=dtype, device=device),
+                torch.randn(tuple(um.shape), dtype=dtype, device=device),
+                torch.randn(tuple(weight.shape), dtype=dtype, device=device),
+                x_example,
+                y_example,
+            )
+        elif nu == 2:
+            graph_module = torch.fx.symbolic_trace(
+                lambda u_t, um_t, w_t, x0_t, x1_t, y_t: torch.einsum(
+                    NONSOC_CONTRACTION_EQUATIONS[2], u_t, um_t, w_t, x0_t, x1_t, y_t
+                )
+            )
+            example_inputs = (
+                torch.randn(tuple(u.shape), dtype=dtype, device=device),
+                torch.randn(tuple(um.shape), dtype=dtype, device=device),
+                torch.randn(tuple(weight.shape), dtype=dtype, device=device),
+                x_example,
+                x_example,
+                y_example,
+            )
+        elif nu == 3:
+            graph_module = torch.fx.symbolic_trace(
+                lambda u_t, um_t, w_t, x0_t, x1_t, x2_t, y_t: torch.einsum(
+                    NONSOC_CONTRACTION_EQUATIONS[3], u_t, um_t, w_t, x0_t, x1_t, x2_t, y_t
+                )
+            )
+            example_inputs = (
+                torch.randn(tuple(u.shape), dtype=dtype, device=device),
+                torch.randn(tuple(um.shape), dtype=dtype, device=device),
+                torch.randn(tuple(weight.shape), dtype=dtype, device=device),
+                x_example,
+                x_example,
+                x_example,
+                y_example,
+            )
+        else:
+            raise ValueError(f"Unsupported correlation order: {nu}")
+
+        return opt_einsum_fx.optimize_einsums_full(
+            model=graph_module,
+            example_inputs=example_inputs,
+        )
+
+    def _ensure_optimized_contractions(self) -> None:
+        if hasattr(self, "optimized_contractions"):
+            return
+        self.optimized_contractions = torch.nn.ModuleDict()
+        for nu in range(1, self.correlation + 1):
+            self.optimized_contractions[str(nu)] = self._build_optimized_contraction(nu)
+
+    def _build_sparse_paths(self, nu: int) -> dict[str, torch.Tensor]:
+        u = self.U_tensors(nu)
+        um = self.U_magmom_tensors(nu)
+        u_idx = (u != 0).nonzero(as_tuple=False)
+        um_idx = (um != 0).nonzero(as_tuple=False)
+        u_val = u[tuple(u_idx[:, dim] for dim in range(u_idx.shape[1]))]
+        um_val = um[tuple(um_idx[:, dim] for dim in range(um_idx.shape[1]))]
+
+        n_u = u_idx.shape[0]
+        n_um = um_idx.shape[0]
+        path_count = n_u * n_um
+
+        coeff = (u_val[:, None] * um_val[None, :]).reshape(path_count)
+        path = {"coeff": coeff}
+
+        for dim, label in enumerate(("i", "j", "f")[:nu]):
+            path[label] = u_idx[:, dim][:, None].expand(n_u, n_um).reshape(path_count)
+        path["k"] = u_idx[:, nu][:, None].expand(n_u, n_um).reshape(path_count)
+
+        for dim, label in enumerate(("l", "m", "g")[:nu]):
+            path[label] = um_idx[None, :, dim].expand(n_u, n_um).reshape(path_count)
+        path["q"] = um_idx[None, :, nu].expand(n_u, n_um).reshape(path_count)
+        return path
+
+    def _ensure_sparse_paths(self) -> None:
+        if hasattr(self, "sparse_path_buffers"):
+            return
+        self.sparse_path_buffers = {}
+        for nu in range(1, self.correlation + 1):
+            path = self._build_sparse_paths(nu)
+            self.sparse_path_buffers[nu] = tuple(path.keys())
+            for key, value in path.items():
+                self.register_buffer(f"sparse_nu{nu}_{key}", value)
+
+    def _get_sparse_path(self, nu: int) -> dict[str, torch.Tensor]:
+        self._ensure_sparse_paths()
+        keys = self.sparse_path_buffers[nu]
+        return {key: getattr(self, f"sparse_nu{nu}_{key}") for key in keys}
+
+    def forward_reference(self, x: torch.Tensor, y: torch.Tensor):
         # x is of shape A_{i, k, lm, l'm'}
-        # 'cg_r, cg_m, A_{k, lm, l',m}
-
+        # y is node_attrs one-hot (B, e)
         assert self.irrep_out.lmax == 0
-        bs = x.shape[0]
-        outs_dict = dict()
 
-        parse_instruction_1 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)]+ ["ik,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)]+ ["lq,"]+ ["ekqa,bail,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
+        out = None
+        for nu in range(1, self.correlation + 1):
+            weight_nu = self.weights_max if nu == self.correlation else self.weights[nu - 1]
 
-        parse_instruction_2 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["ijk,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["lmq,"] + ["ekqa,bail,bajm,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
-        parse_instruction_3 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["ijfk,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["lmgq,"] + ["ekqa,bail,bajm,bafg,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
-        parse_instruction_list = ["".join(parse_instruction_1), "".join(parse_instruction_2), "".join(parse_instruction_3)]
-        
-        for nu in range(1, self.correlation+1):
             if nu == 1:
-                outs_dict[nu] = contract(parse_instruction_list[nu-1], self.U_tensors(nu), self.U_magmom_tensors(nu), self.weights[nu-1], x, y)
+                term = contract(
+                    NONSOC_CONTRACTION_EQUATIONS[1],
+                    self.U_tensors(nu),
+                    self.U_magmom_tensors(nu),
+                    weight_nu,
+                    x,
+                    y,
+                )
             elif nu == 2:
-                outs_dict[nu] = contract(parse_instruction_list[nu-1], self.U_tensors(nu), self.U_magmom_tensors(nu), self.weights[nu-1], x, x, y)
+                term = contract(
+                    NONSOC_CONTRACTION_EQUATIONS[2],
+                    self.U_tensors(nu),
+                    self.U_magmom_tensors(nu),
+                    weight_nu,
+                    x,
+                    x,
+                    y,
+                )
             elif nu == 3:
-                outs_dict[nu] = contract(parse_instruction_list[nu-1], self.U_tensors(nu), self.U_magmom_tensors(nu), self.weights_max, x, x, x, y)
-        
-        out = outs_dict[self.correlation]
-        for nu in range(self.correlation - 1, 0, -1):
-            out += outs_dict[nu]
+                term = contract(
+                    NONSOC_CONTRACTION_EQUATIONS[3],
+                    self.U_tensors(nu),
+                    self.U_magmom_tensors(nu),
+                    weight_nu,
+                    x,
+                    x,
+                    x,
+                    y,
+                )
+            else:
+                raise ValueError(f"Unsupported correlation order: {nu}")
+
+            out = term if out is None else (out + term)
+
         return out.view(out.shape[0], -1)
 
+    def forward_optimized(self, x: torch.Tensor, y: torch.Tensor):
+        assert self.irrep_out.lmax == 0
+        self._ensure_optimized_contractions()
+
+        out = None
+        for nu in range(1, self.correlation + 1):
+            weight_nu = self.weights_max if nu == self.correlation else self.weights[nu - 1]
+            optimized = self.optimized_contractions[str(nu)]
+
+            if nu == 1:
+                term = optimized(
+                    self.U_tensors(nu),
+                    self.U_magmom_tensors(nu),
+                    weight_nu,
+                    x,
+                    y,
+                )
+            elif nu == 2:
+                term = optimized(
+                    self.U_tensors(nu),
+                    self.U_magmom_tensors(nu),
+                    weight_nu,
+                    x,
+                    x,
+                    y,
+                )
+            elif nu == 3:
+                term = optimized(
+                    self.U_tensors(nu),
+                    self.U_magmom_tensors(nu),
+                    weight_nu,
+                    x,
+                    x,
+                    x,
+                    y,
+                )
+            else:
+                raise ValueError(f"Unsupported correlation order: {nu}")
+
+            out = term if out is None else (out + term)
+
+        return out.view(out.shape[0], -1)
+
+    def forward_sparse(self, x: torch.Tensor, y: torch.Tensor):
+        assert self.irrep_out.lmax == 0
+        self._ensure_sparse_paths()
+
+        out = None
+        for nu in range(1, self.correlation + 1):
+            weight_nu = self.weights_max if nu == self.correlation else self.weights[nu - 1]
+            path = self._get_sparse_path(nu)
+            coeff = path["coeff"]
+            w = weight_nu[:, path["k"], path["q"], :]
+
+            if nu == 1:
+                x0 = x[:, :, path["i"], path["l"]]
+                term = torch.einsum("epa,bap,be,p->ba", w, x0, y, coeff)
+            elif nu == 2:
+                x0 = x[:, :, path["i"], path["l"]]
+                x1 = x[:, :, path["j"], path["m"]]
+                term = torch.einsum("epa,bap,bap,be,p->ba", w, x0, x1, y, coeff)
+            elif nu == 3:
+                x0 = x[:, :, path["i"], path["l"]]
+                x1 = x[:, :, path["j"], path["m"]]
+                x2 = x[:, :, path["f"], path["g"]]
+                term = torch.einsum("epa,bap,bap,bap,be,p->ba", w, x0, x1, x2, y, coeff)
+            else:
+                raise ValueError(f"Unsupported correlation order: {nu}")
+
+            out = term if out is None else (out + term)
+
+        return out.view(out.shape[0], -1)
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
+        return self.forward_optimized(x, y)
+    
     def U_tensors(self, nu: int):
         return dict(self.named_buffers())[f"U_matrix_{nu}"]
-    
+
     def U_magmom_tensors(self, nu: int):
         return dict(self.named_buffers())[f"U_matrix_magmom_{nu}"]
+
+
+    # def forward(self, x: torch.Tensor, y: torch.Tensor):
+    #     # x is of shape A_{i, k, lm, l'm'}
+    #     # 'cg_r, cg_m, A_{k, lm, l',m}
+
+    #     assert self.irrep_out.lmax == 0
+    #     bs = x.shape[0]
+    #     outs_dict = dict()
+
+    #     parse_instruction_1 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)]+ ["ik,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)]+ ["lq,"]+ ["ekqa,bail,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
+
+    #     parse_instruction_2 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["ijk,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["lmq,"] + ["ekqa,bail,bajm,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
+    #     parse_instruction_3 = ([ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["ijfk,"] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + ["lmgq,"] + ["ekqa,bail,bajm,bafg,be->ba"] + [ALPHABET[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)] + [ALPHABET_MAGMOM[j] for j in range(1 + min(self.irrep_out.lmax, 1) - 1)])
+    #     parse_instruction_list = ["".join(parse_instruction_1), "".join(parse_instruction_2), "".join(parse_instruction_3)]
+        
+    #     for nu in range(1, self.correlation + 1):
+    #         # Prefer the top-order tensor for nu==correlation.
+    #         # For lower orders, use weights[nu-1] when available.
+    #         if nu == self.correlation:
+    #             weight_nu = self.weights_max
+    #         else:
+    #             weight_nu = self.weights[nu - 1]
+
+    #         LOGGER.info(
+    #             "[NonSOCContraction] forward nu=%s U=%s U_mag=%s W=%s x=%s y=%s",
+    #             nu,
+    #             tuple(self.U_tensors(nu).shape),
+    #             tuple(self.U_magmom_tensors(nu).shape),
+    #             tuple(weight_nu.shape),
+    #             tuple(x.shape),
+    #             tuple(y.shape),
+    #         )
+
+    #         if nu == 1:
+    #             outs_dict[nu] = contract(
+    #                 parse_instruction_list[nu - 1],
+    #                 self.U_tensors(nu),
+    #                 self.U_magmom_tensors(nu),
+    #                 weight_nu,
+    #                 x,
+    #                 y,
+    #             )
+    #         elif nu == 2:
+    #             outs_dict[nu] = contract(
+    #                 parse_instruction_list[nu - 1],
+    #                 self.U_tensors(nu),
+    #                 self.U_magmom_tensors(nu),
+    #                 weight_nu,
+    #                 x,
+    #                 x,
+    #                 y,
+    #             )
+    #         elif nu == 3:
+    #             outs_dict[nu] = contract(
+    #                 parse_instruction_list[nu - 1],
+    #                 self.U_tensors(nu),
+    #                 self.U_magmom_tensors(nu),
+    #                 weight_nu,
+    #                 x,
+    #                 x,
+    #                 x,
+    #                 y,
+    #             )
+        
+    #     out = outs_dict[self.correlation]
+    #     for nu in range(self.correlation - 1, 0, -1):
+    #         out += outs_dict[nu]
+    #     return out.view(out.shape[0], -1)
+
+    # def U_tensors(self, nu: int):
+    #     return dict(self.named_buffers())[f"U_matrix_{nu}"]
+    
+    # def U_magmom_tensors(self, nu: int):
+    #     return dict(self.named_buffers())[f"U_matrix_magmom_{nu}"]
 
 
 @compile_mode("script")
@@ -215,7 +836,6 @@ class SymmetricContraction(CodeGenMixin, torch.nn.Module):
 
         self.irreps_in = o3.Irreps(irreps_in)
         self.irreps_out = o3.Irreps(irreps_out)
-
         del irreps_in, irreps_out
 
         if not isinstance(correlation, tuple):

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -182,6 +182,47 @@ def compute_hessians_loop(
     hessian = torch.stack(hessian)
     return hessian
 
+def compute_forces_virials_magforces(
+    energy: torch.Tensor,
+    positions: torch.Tensor,
+    displacement: torch.Tensor,
+    cell: torch.Tensor,
+    magmoms: Optional[torch.Tensor] = None,
+    training: bool = True,
+    compute_stress: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+    grad_outputs = [torch.ones_like(energy)]
+
+    # Pack all inputs into a list
+    inputs = [positions, displacement]
+    if magmoms is not None:
+        inputs.append(magmoms)
+
+    grads = torch.autograd.grad(
+        outputs=[energy],
+        inputs=inputs,
+        grad_outputs=grad_outputs,
+        retain_graph=training,
+        create_graph=training,
+        allow_unused=True,
+    )
+
+    # Unpack the gradients
+    forces = grads[0] if grads[0] is not None else torch.zeros_like(positions)
+    virials = grads[1] if grads[1] is not None else torch.zeros_like(displacement)
+    mag_forces = grads[2] if magmoms is not None and grads[2] is not None else (
+        torch.zeros_like(magmoms) if magmoms is not None else None
+    )
+
+    # Compute stress if requested
+    stress = None
+    if compute_stress:
+        cell = cell.view(-1, 3, 3)
+        volume = torch.linalg.det(cell).abs().unsqueeze(-1)
+        stress = virials / volume.view(-1, 1, 1)
+        stress = torch.where(torch.abs(stress) < 1e10, stress, torch.zeros_like(stress))
+
+    return -forces, -virials, stress, -mag_forces if mag_forces is not None else None
 
 def get_outputs(
     energy: torch.Tensor,
@@ -202,7 +243,18 @@ def get_outputs(
     Optional[torch.Tensor],
 ]:
     # Check individual contribution
-    if (compute_virials or compute_stress) and displacement is not None:
+    if ((compute_virials or compute_stress) and displacement is not None) and compute_magforces:
+        assert magmoms is not None, "Magnetic momenet must be inputed to get magnetic forces"
+        forces, virials, stress, mag_forces = compute_forces_virials_magforces(
+            energy=energy,
+            positions=positions,
+            displacement=displacement,
+            cell=cell,
+            magmoms=magmoms,
+            training=True,
+            compute_stress=True
+        )
+    elif (compute_virials or compute_stress) and displacement is not None:
         forces, virials, stress = compute_forces_virials(
             energy=energy,
             positions=positions,
@@ -211,6 +263,7 @@ def get_outputs(
             compute_stress=compute_stress,
             training=(training or compute_hessian or compute_magforces),
         )
+        mag_forces = None
     elif compute_force:
         forces, virials, stress = (
             compute_forces(
@@ -221,22 +274,24 @@ def get_outputs(
             None,
             None,
         )
+        mag_forces = None
     else:
-        forces, virials, stress = (None, None, None)
+        forces, virials, stress, mag_forces = (None, None, None, None)
+    ## ==
     if compute_hessian:
         assert forces is not None, "Forces must be computed to get the hessian"
         hessian = compute_hessians_vmap(forces, positions)
     else:
         hessian = None
-    if compute_magforces:
-        assert magmoms is not None, "Magnetic momenet must be inputed to get magnetic forces"
-        mag_forces = compute_mag_forces(
-            energy=energy,
-            magmoms=magmoms,
-            training=(training or compute_hessian or compute_magforces)
-        )
-    else:
-        mag_forces = None
+    # if compute_magforces:
+    #     assert magmoms is not None, "Magnetic momenet must be inputed to get magnetic forces"
+    #     mag_forces = compute_mag_forces(
+    #         energy=energy,
+    #         magmoms=magmoms,
+    #         training=(training or compute_hessian or compute_magforces)
+    #     )
+    # else:
+    #     mag_forces = None
     return forces, virials, stress, hessian, mag_forces
 
 

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -42,8 +42,6 @@ def compute_mag_forces(
     energy: torch.Tensor, magmoms: torch.Tensor, training: bool = True
 ) -> torch.Tensor:
     grad_outputs: List[Optional[torch.Tensor]] = [torch.ones_like(energy)]
-    #print("energy grad_fn:", energy.grad_fn)
-    #print("magmoms shape: ", magmoms.shape)
     gradient = torch.autograd.grad(
         outputs=[energy],  # [n_graphs, ]
         inputs=[magmoms],  # [n_nodes, 3]

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -490,6 +490,18 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=str,
         default="REF_charges",
     )
+    parser.add_argument(
+        "--magmom_key",
+        help="Key of magnetic moment in training xyz",
+        type=str,
+        default="REF_magmom",
+    )
+    parser.add_argument(
+        "--magforces_key",
+        help="Key of magnetic forces in training xyz",
+        type=str,
+        default="REF_magforces",
+    )
 
     # Pretraining-specific keys
     parser.add_argument(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -544,6 +544,17 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         dest="swa_forces_weight",
     )
     parser.add_argument(
+        "--magforces_weight", help="weight of mag forces loss", type=float, default=100.0
+    )
+    parser.add_argument(
+        "--swa_magforces_weight",
+        "--stage_two_magforces_weight",
+        help="weight of magforces loss after starting Stage Two (previously called swa)",
+        type=float,
+        default=100.0,
+        dest="swa_magforces_weight",
+    )
+    parser.add_argument(
         "--energy_weight", help="weight of energy loss", type=float, default=1.0
     )
     parser.add_argument(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -132,6 +132,9 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticSolidHarmonicsSpinOrbitCoupledScaleShiftMACE",
             "MagneticSolidHarmonicsFlexibleSOScaleShiftMACE",
             "MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE",
         ],
     )
     parser.add_argument(
@@ -883,6 +886,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=str,
         default="SymmetricContraction",
     )
+    parser.add_argument(
+        "--train_one_body_contribution",
+        type=str2bool,
+        default=True
+    )
+
     return parser
 
 

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -125,7 +125,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "ScaleShiftBOTNet",
             "AtomicDipolesMACE",
             "EnergyDipolesMACE",
-            "MagneticScaleShiftMACE"
+            "MagneticScaleShiftMACE",
+            "MagneticSolidHarmonicsScaleShiftMACE"
         ],
     )
     parser.add_argument(
@@ -174,6 +175,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "RealAgnosticDensityInteractionBlock",
             "RealAgnosticDensityResidualInteractionBlock",
             "MagneticRealAgnosticDensityInteractionBlock",
+            "MagneticRealAgnosticSeparateRadialDensityInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -187,6 +189,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "RealAgnosticDensityInteractionBlock",
             "RealAgnosticDensityResidualInteractionBlock",
             "MagneticRealAgnosticDensityInteractionBlock",
+            "MagneticRealAgnosticSeparateRadialDensityInteractionBlock",
         ],
     )
     parser.add_argument(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -190,6 +190,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -210,6 +211,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
         ],
     )
     parser.add_argument(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -806,6 +806,15 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=str2bool,
         default=False,
     )
+
+    # optional for data augmentation
+    parser.add_argument(
+        "--data_aug_magmom",
+        help="Whether to use data agumentation on manetic moment training",
+        type=str2bool,
+        default=False,
+    )
+
     # options for using Weights and Biases for experiment tracking
     # to install see https://wandb.ai
     parser.add_argument(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -191,6 +191,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock",
+            "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -212,6 +214,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock",
+            "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock",
         ],
     )
     parser.add_argument(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -125,6 +125,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "ScaleShiftBOTNet",
             "AtomicDipolesMACE",
             "EnergyDipolesMACE",
+            "MagneticScaleShiftMACE"
         ],
     )
     parser.add_argument(
@@ -172,6 +173,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "RealAgnosticInteractionBlock",
             "RealAgnosticDensityInteractionBlock",
             "RealAgnosticDensityResidualInteractionBlock",
+            "MagneticRealAgnosticDensityInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -184,6 +186,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "RealAgnosticInteractionBlock",
             "RealAgnosticDensityInteractionBlock",
             "RealAgnosticDensityResidualInteractionBlock",
+            "MagneticRealAgnosticDensityInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -799,6 +802,38 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "forces_weight",
         ],
     )
+
+    # --- magnetic ace ---
+    parser.add_argument(
+        "--m_max",
+        help="|m| basis m_max for magnetic momgent",
+        type=float,
+        default=3,
+    )
+    parser.add_argument(
+        "--max_m_ell",
+        help="max_ell for magnetic mace",
+        type=int,
+        default=3,
+    )
+    parser.add_argument(
+        "--num_mag_radial_basis",
+        help="number of radial basis for magnetic mace",
+        type=int,
+        default=3,
+    )
+    parser.add_argument(
+        "--contraction_cls_first",
+        help="Type of first contraction block used",
+        type=str,
+        default="SymmetricContraction",
+    )
+    parser.add_argument(
+        "--contraction_cls",
+        help="Type of contraction blocks used except first layer",
+        type=str,
+        default="SymmetricContraction",
+    )
     return parser
 
 
@@ -958,6 +993,7 @@ def build_preprocess_arg_parser() -> argparse.ArgumentParser:
         type=int,
         default=123,
     )
+
     return parser
 
 

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -808,7 +808,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         "--m_max",
         help="|m| basis m_max for magnetic momgent",
         type=float,
-        default=3,
+        nargs='+',
     )
     parser.add_argument(
         "--max_m_ell",

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -276,6 +276,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default=True,
     )
     parser.add_argument(
+        "--compute_magforces",
+        help="Select True to compute stress",
+        type=str2bool,
+        default=True,
+    )
+    parser.add_argument(
         "--compute_stress",
         help="Select True to compute stress",
         type=str2bool,

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -126,7 +126,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "AtomicDipolesMACE",
             "EnergyDipolesMACE",
             "MagneticScaleShiftMACE",
-            "MagneticSolidHarmonicsScaleShiftMACE"
+            "MagneticSolidHarmonicsScaleShiftMACE",
+            "MagneticSolidHarmonicsSeparateReadoutScaleShiftMACE",
+            "MagneticSolidHarmonicsSeparateReadoutMixMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledScaleShiftMACE",
+            "MagneticSolidHarmonicsFlexibleSOScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE",
         ],
     )
     parser.add_argument(
@@ -176,6 +181,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "RealAgnosticDensityResidualInteractionBlock",
             "MagneticRealAgnosticDensityInteractionBlock",
             "MagneticRealAgnosticSeparateRadialDensityInteractionBlock",
+            "MagneticRealAgnosticSeparateRadialCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticSeparateRadialCoupledPosToMagDensityInteractionBlock",
+            "MagneticRealAgnosticSeparateRadialDensityTestingInteractionBlock",
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -190,6 +201,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "RealAgnosticDensityResidualInteractionBlock",
             "MagneticRealAgnosticDensityInteractionBlock",
             "MagneticRealAgnosticSeparateRadialDensityInteractionBlock",
+            "MagneticRealAgnosticSeparateRadialCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticSeparateRadialCoupledPosToMagDensityInteractionBlock",
+            "MagneticRealAgnosticSeparateRadialDensityTestingInteractionBlock",
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticFlexibleSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
         ],
     )
     parser.add_argument(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -556,6 +556,20 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default=None,
     )
     parser.add_argument(
+        "--pt_magmom_key",
+        help="Key of magnetic moment in training xyz",
+        type=str,
+        default="REF_magmom",
+    )
+    parser.add_argument(
+        "--pt_magforces_key",
+        help="Key of magnetic forces in training xyz",
+        type=str,
+        default="REF_magforces",
+    )
+
+
+    parser.add_argument(
         "--skip_evaluate_heads",
         help="Comma-separated list of heads to skip during final evaluation",
         type=str,
@@ -904,7 +918,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--train_one_body_contribution",
         type=str2bool,
-        default=True
+        default=False
     )
 
     return parser

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -135,6 +135,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE",
             "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE",
             "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE",
         ],
     )
     parser.add_argument(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -136,6 +136,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE",
             "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE",
             "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE",
         ],
     )
     parser.add_argument(
@@ -194,6 +196,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock",
             "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock",
+            "MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -217,6 +220,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
             "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock",
             "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock",
+            "MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -885,7 +889,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         ],
     )
 
-    # --- magnetic ace ---
+    # --- magnetic mace ---
     parser.add_argument(
         "--num_mag_radial_basis_one_body",
         help="number of radial basis for one body contribution in magnetic mace",

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -138,6 +138,9 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE",
             "MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE",
             "MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesFixingGinzburgSelfMagmomScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomFixingScaleShiftMACE",
+            "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesEvenSplineSelfMagmomScaleShiftMACE",
         ],
     )
     parser.add_argument(
@@ -596,6 +599,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "huber",
             "universal",
             "energy_forces_dipole",
+            "EvenSpline1BodyLoss",
         ],
     )
     parser.add_argument(
@@ -900,6 +904,24 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--m_max",
         help="|m| basis m_max for magnetic momgent",
+        type=float,
+        nargs='+',
+    )
+    parser.add_argument(
+        "--m_max_1b",
+        help="|m| basis m_max for one body magnetic momgent",
+        type=float,
+        nargs='+',
+    )
+    parser.add_argument(
+        "--prefactor",
+        help="|m| basis m_max for one body magnetic momgent",
+        type=float,
+        nargs='+',
+    )
+    parser.add_argument(
+        "--lambda_smooth",
+        help="regularization constant used",
         type=float,
         nargs='+',
     )

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -887,6 +887,13 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
 
     # --- magnetic ace ---
     parser.add_argument(
+        "--num_mag_radial_basis_one_body",
+        help="number of radial basis for one body contribution in magnetic mace",
+        type=int,
+        default=10,
+#        nargs='+',
+    )
+    parser.add_argument(
         "--m_max",
         help="|m| basis m_max for magnetic momgent",
         type=float,
@@ -900,9 +907,9 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--num_mag_radial_basis",
-        help="number of radial basis for magnetic mace",
+        help="number of radial basis for magnetic part",
         type=int,
-        default=3,
+        default=8,
     )
     parser.add_argument(
         "--contraction_cls_first",

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -200,6 +200,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock",
             "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock",
             "MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticSpinOrbitCoupledDensityWithMagmomInteractionBlock",
+            "MagneticRealAgnosticResidueSpinOrbitCoupledDensityWithMagmomInteractionBlock",
         ],
     )
     parser.add_argument(
@@ -224,6 +226,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "MagneticRealAgnosticResidueSpinOrbitCoupledMagmomDensityInteractionBlock",
             "MagneticRealAgnosticSpinOrbitCoupledMagmomDensityInteractionBlock",
             "MagneticRealAgnosticNonSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticSpinOrbitCoupledDensityWithMagmomInteractionBlock",
+            "MagneticRealAgnosticResidueSpinOrbitCoupledDensityWithMagmomInteractionBlock",
         ],
     )
     parser.add_argument(

--- a/mace/tools/finetuning_utils.py
+++ b/mace/tools/finetuning_utils.py
@@ -3,7 +3,26 @@ import torch
 from mace.tools.utils import AtomicNumberTable
 
 
+
 def load_foundations_elements(
+    model: torch.nn.Module,
+    model_foundations: torch.nn.Module,
+    table: AtomicNumberTable,
+    load_readout=False,
+    use_shift=True,
+    use_scale=True,
+    max_L=2,):
+    if "Magnetic" not in str(model.__class__.__name__):
+        return load_foundations_elements_default(
+            model, model_foundations, table, load_readout, use_shift, use_scale, max_L
+        )
+    else:
+        return load_foundations_elements_magnetic(
+            model, model_foundations, table, load_readout, use_shift, use_scale, max_L
+        )
+
+
+def load_foundations_elements_magnetic(
     model: torch.nn.Module,
     model_foundations: torch.nn.Module,
     table: AtomicNumberTable,
@@ -21,8 +40,254 @@ def load_foundations_elements(
     new_z_table = table
     num_species_foundations = len(z_table.zs)
 
-    if z_table.zs == table.zs:
-        return model_foundations
+    num_channels_foundation = (
+        model_foundations.node_embedding.linear.weight.shape[0]
+        // num_species_foundations
+    )
+    indices_weights = [z_table.z_to_index(z) for z in new_z_table.zs]
+    num_radial = model.radial_embedding.out_dim
+    num_mag_radial = model.mag_radial_embedding.num_basis
+    num_species = len(indices_weights)
+    max_ell = model.spherical_harmonics._lmax  # pylint: disable=protected-access
+    model.node_embedding.linear.weight = torch.nn.Parameter(
+        model_foundations.node_embedding.linear.weight.view(
+            num_species_foundations, -1
+        )[indices_weights, :]
+        .flatten()
+        .clone()
+        / (num_species_foundations / num_species) ** 0.5
+    )
+    if model.radial_embedding.bessel_fn.__class__.__name__ == "BesselBasis":
+        model.radial_embedding.bessel_fn.bessel_weights = torch.nn.Parameter(
+            model_foundations.radial_embedding.bessel_fn.bessel_weights.clone()
+        )
+    
+    for i in range(int(model.num_interactions)):
+        model.interactions[i].linear_up.weight = torch.nn.Parameter(
+            model_foundations.interactions[i].linear_up.weight.clone()
+        )
+        model.interactions[i].avg_num_neighbors = model_foundations.interactions[
+            i
+        ].avg_num_neighbors
+        for j in range(4):  # Assuming 4 layers in conv_tp_weights,
+            layer_name = f"layer{j}"
+            if j == 0:
+                getattr(model.interactions[i].conv_tp_weights, layer_name).weight = (
+                    torch.nn.Parameter(
+                        getattr(
+                            model_foundations.interactions[i].conv_tp_weights,
+                            layer_name,
+                        )
+                        .weight[:num_radial+num_mag_radial, :]
+                        .clone()
+                    )
+                )
+            else:
+                getattr(model.interactions[i].conv_tp_weights, layer_name).weight = (
+                    torch.nn.Parameter(
+                        getattr(
+                            model_foundations.interactions[i].conv_tp_weights,
+                            layer_name,
+                        ).weight.clone()
+                    )
+                )
+
+        # conv_tp_weights_magmom
+        for j in range(1):  # Assuming 4 layers in conv_tp_weights,
+            layer_name = f"layer{j}"
+            if j == 0:
+                getattr(model.interactions[i].conv_tp_weights_magmom, layer_name).weight = (
+                    torch.nn.Parameter(
+                        getattr(
+                            model_foundations.interactions[i].conv_tp_weights_magmom,
+                            layer_name,
+                        )
+                        .weight.clone()
+                    )
+                )
+            else:
+                getattr(model.interactions[i].conv_tp_weights_magmom, layer_name).weight = (
+                    torch.nn.Parameter(
+                        getattr(
+                            model_foundations.interactions[i].conv_tp_weights_magmom,
+                            layer_name,
+                        ).weight.clone()
+                    )
+                )
+        
+        model.interactions[i].magmom_linear.weight = torch.nn.Parameter(
+            model_foundations.interactions[i].magmom_linear.weight.clone()
+        )
+        if model.interactions[i].__class__.__name__ in [
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
+        ]:
+            #import pdb; pdb.set_trace()
+            model.interactions[i].magmom_skip_tp.weight = torch.nn.Parameter(
+                model_foundations.interactions[i].magmom_skip_tp.weight.flatten().clone()
+                # .reshape(
+                #     num_channels_foundation,
+                #     num_species_foundations,
+                #     num_channels_foundation,
+                # )[:, indices_weights, :]
+                # .flatten()
+                # .clone()
+                # / (num_species_foundations / num_species) ** 0.5
+            )
+        else:
+            model.interactions[i].skip_tp.weight = torch.nn.Parameter(
+                model_foundations.interactions[i].skip_tp.weight.flatten().clone()
+                # .reshape(
+                #     num_channels_foundation,
+                #     (max_ell + 1),
+                #     num_species_foundations,
+                #     num_channels_foundation,
+                # )[:, :, indices_weights, :]
+                # .flatten()
+                # .clone()
+                # / (num_species_foundations / num_species) ** 0.5
+            )
+        if model.interactions[i].__class__.__name__ in [
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock",
+            "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
+        ]:
+            # Assuming only 1 layer in density_fn
+            getattr(model.interactions[i].density_fn, "layer0").weight = (
+                torch.nn.Parameter(
+                    getattr(
+                        model_foundations.interactions[i].density_fn,
+                        "layer0",
+                    ).weight.clone()
+                )
+            )
+    # Transferring products
+    for i in range(2):  # Assuming 2 products modules
+        max_range = max_L + 1 if i == 0 else 1
+        for j in range(max_range):  # Assuming 3 contractions in symmetric_contractions
+            model.products[i].symmetric_contractions.contractions[j].weights_max = (
+                torch.nn.Parameter(
+                    model_foundations.products[i]
+                    .symmetric_contractions.contractions[j]
+                    .weights_max[indices_weights, :, :]
+                    .clone()
+                )
+            )
+
+            for k in range(2):  # Assuming 2 weights in each contraction
+                model.products[i].symmetric_contractions.contractions[j].weights[k] = (
+                    torch.nn.Parameter(
+                        model_foundations.products[i]
+                        .symmetric_contractions.contractions[j]
+                        .weights[k][indices_weights, :, :]
+                        .clone()
+                    )
+                )
+
+        model.products[i].conv_tp.weight = torch.nn.Parameter(
+            model_foundations.products[i].conv_tp.weight.clone()
+        )
+        # model.products[i].conv_tp_weights.weight = torch.nn.Parameter(
+        #     model_foundations.products[i].conv_tp_weights.weight.clone()
+        # )
+        for j in range(4):  # Assuming 4 layers in conv_tp_weights,
+            layer_name = f"layer{j}"
+            if j == 0:
+                getattr(model.products[i].conv_tp_weights, layer_name).weight = (
+                    torch.nn.Parameter(
+                        getattr(
+                            model_foundations.products[i].conv_tp_weights,
+                            layer_name,
+                        )
+                        .weight[:num_mag_radial, :]
+                        .clone()
+                    )
+                )
+            else:
+                getattr(model.products[i].conv_tp_weights, layer_name).weight = (
+                    torch.nn.Parameter(
+                        getattr(
+                            model_foundations.products[i].conv_tp_weights,
+                            layer_name,
+                        ).weight.clone()
+                    )
+                )
+        model.products[i].linear_ori.weight = torch.nn.Parameter(
+            model_foundations.products[i].linear_ori.weight.clone()
+        )        
+        model.products[i].linear.weight = torch.nn.Parameter(
+            model_foundations.products[i].linear.weight.clone()
+        )
+
+    if load_readout:
+        # Transferring readouts
+        model_readouts_zero_linear_weight = model.readouts[0].linear.weight.clone()
+        model_readouts_zero_linear_weight = (
+            model_foundations.readouts[0]
+            .linear.weight.view(num_channels_foundation, -1)
+            .repeat(1, len(model_heads))
+            .flatten()
+            .clone()
+        )
+        model.readouts[0].linear.weight = torch.nn.Parameter(
+            model_readouts_zero_linear_weight
+        )
+
+        shape_input_1 = (
+            model_foundations.readouts[1].linear_1.__dict__["irreps_out"].num_irreps
+        )
+        shape_output_1 = model.readouts[1].linear_1.__dict__["irreps_out"].num_irreps
+        model_readouts_one_linear_1_weight = model.readouts[1].linear_1.weight.clone()
+        model_readouts_one_linear_1_weight = (
+            model_foundations.readouts[1]
+            .linear_1.weight.view(num_channels_foundation, -1)
+            .repeat(1, len(model_heads))
+            .flatten()
+            .clone()
+        )
+        model.readouts[1].linear_1.weight = torch.nn.Parameter(
+            model_readouts_one_linear_1_weight
+        )
+        model_readouts_one_linear_2_weight = model.readouts[1].linear_2.weight.clone()
+        model_readouts_one_linear_2_weight = model_foundations.readouts[
+            1
+        ].linear_2.weight.view(shape_input_1, -1).repeat(
+            len(model_heads), len(model_heads)
+        ).flatten().clone() / (
+            ((shape_input_1) / (shape_output_1)) ** 0.5
+        )
+        model.readouts[1].linear_2.weight = torch.nn.Parameter(
+            model_readouts_one_linear_2_weight
+        )
+    if model_foundations.scale_shift is not None:
+        if use_scale:
+            model.scale_shift.scale = model_foundations.scale_shift.scale.repeat(
+                len(model_heads)
+            ).clone()
+        if use_shift:
+            model.scale_shift.shift = model_foundations.scale_shift.shift.repeat(
+                len(model_heads)
+            ).clone()
+    return model
+
+def load_foundations_elements_default(
+    model: torch.nn.Module,
+    model_foundations: torch.nn.Module,
+    table: AtomicNumberTable,
+    load_readout=False,
+    use_shift=True,
+    use_scale=True,
+    max_L=2,
+):
+    """
+    Load the foundations of a model into a model for fine-tuning.
+    """
+    assert model_foundations.r_max == model.r_max
+    z_table = AtomicNumberTable([int(z) for z in model_foundations.atomic_numbers])
+    model_heads = model.heads
+    new_z_table = table
+    num_species_foundations = len(z_table.zs)
+
+    #if z_table.zs == table.zs:
+    #    return model_foundations
 
     num_channels_foundation = (
         model_foundations.node_embedding.linear.weight.shape[0]

--- a/mace/tools/finetuning_utils.py
+++ b/mace/tools/finetuning_utils.py
@@ -286,8 +286,8 @@ def load_foundations_elements_default(
     new_z_table = table
     num_species_foundations = len(z_table.zs)
 
-    #if z_table.zs == table.zs:
-    #    return model_foundations
+    if z_table.zs == table.zs:
+       return model_foundations
 
     num_channels_foundation = (
         model_foundations.node_embedding.linear.weight.shape[0]

--- a/mace/tools/finetuning_utils.py
+++ b/mace/tools/finetuning_utils.py
@@ -20,6 +20,10 @@ def load_foundations_elements(
     model_heads = model.heads
     new_z_table = table
     num_species_foundations = len(z_table.zs)
+
+    if z_table.zs == table.zs:
+        return model_foundations
+
     num_channels_foundation = (
         model_foundations.node_embedding.linear.weight.shape[0]
         // num_species_foundations

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -36,6 +36,7 @@ def configure_model(
         "virials": compute_virials,
         "stress": compute_stress,
         "dipoles": args.compute_dipole,
+        "magforces": args.compute_magforces,
     }
     logging.info(
         f"During training the following quantities will be reported: {', '.join([f'{report}' for report, value in output_args.items() if value])}"

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -194,7 +194,62 @@ def _build_model(
     args, model_config, model_config_foundation, heads
 ):  # pylint: disable=too-many-return-statements
 
-    if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE":
+
+    if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodySelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE":
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(
             **model_config,
             pair_repulsion=args.pair_repulsion,

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -192,8 +192,98 @@ def _determine_atomic_inter_shift(mean, heads):
 def _build_model(
     args, model_config, model_config_foundation, heads
 ):  # pylint: disable=too-many-return-statements
-    
-    if args.model == "MagneticSolidHarmonicsScaleShiftMACE":
+
+    if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticSolidHarmonicsFlexibleSOScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsFlexibleSOScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticSolidHarmonicsSpinOrbitCoupledScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticSolidHarmonicsSeparateReadoutMixMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSeparateReadoutMixMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticSolidHarmonicsSeparateReadoutScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSeparateReadoutScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticSolidHarmonicsScaleShiftMACE":
         return modules.MagneticSolidHarmonicsScaleShiftMACE(
             **model_config,
             pair_repulsion=args.pair_repulsion,

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -154,6 +154,8 @@ def configure_model(
             atomic_energies=atomic_energies,
             avg_num_neighbors=args.avg_num_neighbors,
             atomic_numbers=z_table.zs,
+            contraction_cls_first=args.contraction_cls_first,
+            contraction_cls=args.contraction_cls,
         )
         model_config_foundation = None
 
@@ -190,6 +192,25 @@ def _determine_atomic_inter_shift(mean, heads):
 def _build_model(
     args, model_config, model_config_foundation, heads
 ):  # pylint: disable=too-many-return-statements
+    
+    if args.model == "MagneticScaleShiftMACE":
+        return modules.MagneticScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
     if args.model == "MACE":
         if args.interaction_first not in [
             "RealAgnosticInteractionBlock",

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -193,7 +193,25 @@ def _build_model(
     args, model_config, model_config_foundation, heads
 ):  # pylint: disable=too-many-return-statements
     
-    if args.model == "MagneticScaleShiftMACE":
+    if args.model == "MagneticSolidHarmonicsScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    elif args.model == "MagneticScaleShiftMACE":
         return modules.MagneticScaleShiftMACE(
             **model_config,
             pair_repulsion=args.pair_repulsion,

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -64,12 +64,11 @@ def configure_model(
                     args.std if isinstance(args.std, float) else 1.0
                 )
         args.std = atomic_inter_scale
-
     elif (args.mean is None or args.std is None) and args.model != "AtomicDipolesMACE":
         args.mean, args.std = modules.scaling_classes[args.scaling](
             train_loader, atomic_energies
         )
-
+        
     # Build model
     if model_foundation is not None and (args.model in ["MACE", "ScaleShiftMACE"] or "Magnetic" in args.model):
         logging.info("Loading FOUNDATION model")
@@ -201,7 +200,65 @@ def _build_model(
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(
             **model_config_foundation
         )
+
+    if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesEvenSplineSelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesEvenSplineSelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            m_max_1b = args.m_max_1b,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
     
+    if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomFixingScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomFixingScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
+    
+    if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesFixingGinzburgSelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesFixingGinzburgSelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+            num_mag_radial_basis_one_body=args.num_mag_radial_basis_one_body,
+        )
     if args.model == "MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE":
         return modules.MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(
             **model_config,

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -201,7 +201,7 @@ def _build_model(
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(
             **model_config_foundation
         )
-
+    
     if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE":
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(
             **model_config,
@@ -219,6 +219,7 @@ def _build_model(
             m_max=args.m_max,
             max_m_ell=args.max_m_ell,
             num_mag_radial_basis=args.num_mag_radial_basis,
+            num_mag_radial_basis_one_body=args.num_mag_radial_basis_one_body,
         )
     if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE":
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE(
@@ -439,6 +440,7 @@ def _build_model(
         model_config_foundation.pop("m_max", None)
         model_config_foundation.pop("max_m_ell", None)
         model_config_foundation.pop("num_mag_radial_basis", None)
+        model_config_foundation.pop("onebody_magmombasis_coeffs", None)
         
         return modules.ScaleShiftMACE(**model_config_foundation)
     if args.model == "ScaleShiftBOTNet":

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -71,7 +71,7 @@ def configure_model(
         )
 
     # Build model
-    if model_foundation is not None and args.model in ["MACE", "ScaleShiftMACE"]:
+    if model_foundation is not None and (args.model in ["MACE", "ScaleShiftMACE"] or "Magnetic" in args.model):
         logging.info("Loading FOUNDATION model")
         model_config_foundation = extract_config_mace_model(model_foundation)
         model_config_foundation["atomic_energies"] = atomic_energies
@@ -101,7 +101,10 @@ def configure_model(
             )
         model_config_foundation["atomic_inter_scale"] = [1.0] * len(heads)
         args.avg_num_neighbors = model_config_foundation["avg_num_neighbors"]
-        args.model = "FoundationMACE"
+        if "Magnetic" not in args.model:
+            args.model = "FoundationMACE"
+        else:
+            args.model = "MagneticFoundationMACE"
         model_config_foundation["heads"] = heads
         model_config = model_config_foundation
 
@@ -194,7 +197,10 @@ def _build_model(
     args, model_config, model_config_foundation, heads
 ):  # pylint: disable=too-many-return-statements
 
-
+    if args.model == "MagneticFoundationMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(
+            **model_config_foundation
+        )
     if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE":
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE(
             **model_config,
@@ -411,6 +417,10 @@ def _build_model(
             heads=heads,
         )
     if args.model == "FoundationMACE":
+        model_config_foundation.pop("m_max", None)
+        model_config_foundation.pop("max_m_ell", None)
+        model_config_foundation.pop("num_mag_radial_basis", None)
+        
         return modules.ScaleShiftMACE(**model_config_foundation)
     if args.model == "ScaleShiftBOTNet":
         return modules.ScaleShiftBOTNet(

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -202,6 +202,46 @@ def _build_model(
             **model_config_foundation
         )
     
+    if args.model == "MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsFixingNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+            num_mag_radial_basis_one_body=args.num_mag_radial_basis_one_body,
+        )
+    
+    if args.model == "MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsNonSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+            num_mag_radial_basis_one_body=args.num_mag_radial_basis_one_body,
+        )
+    
     if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE":
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(
             **model_config,

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -201,6 +201,25 @@ def _build_model(
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithSelfMagmomScaleShiftMACE(
             **model_config_foundation
         )
+
+    if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE":
+        return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyMultiSpeciesGinzburgSelfMagmomScaleShiftMACE(
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=args.mean,
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            m_max=args.m_max,
+            max_m_ell=args.max_m_ell,
+            num_mag_radial_basis=args.num_mag_radial_basis,
+        )
     if args.model == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE":
         return modules.MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE(
             **model_config,

--- a/mace/tools/multihead_tools.py
+++ b/mace/tools/multihead_tools.py
@@ -33,6 +33,8 @@ class HeadConfig:
     virials_key: Optional[str] = None
     dipole_key: Optional[str] = None
     charges_key: Optional[str] = None
+    magmom_key: Optional[str] = None
+    magforces_key: Optional[str] = None
     keep_isolated_atoms: Optional[bool] = None
     atomic_numbers: Optional[Union[List[int], List[str]]] = None
     mean: Optional[float] = None
@@ -73,6 +75,8 @@ def dict_head_to_dataclass(
         virials_key=head.get("virials_key", args.virials_key),
         dipole_key=head.get("dipole_key", args.dipole_key),
         charges_key=head.get("charges_key", args.charges_key),
+        magmom_key=head.get("magmom_key", args.magmom_key),
+        magforces_key=head.get("magforces_key", args.magforces_key),
         keep_isolated_atoms=head.get("keep_isolated_atoms", args.keep_isolated_atoms),
     )
 

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -650,6 +650,7 @@ def get_loss_fn(
             energy_weight=args.energy_weight,
             forces_weight=args.forces_weight,
             stress_weight=args.stress_weight,
+            magforces_weight=args.magforces_weight,
             huber_delta=args.huber_delta,
         )
     elif args.loss == "dipole":

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -43,10 +43,11 @@ def get_dataset_from_xyz(
     energy_key: str = "REF_energy",
     forces_key: str = "REF_forces",
     stress_key: str = "REF_stress",
-    magforces_key="REF_magforces",
     virials_key: str = "virials",
     dipole_key: str = "dipoles",
     charges_key: str = "charges",
+    magmom_key: str = "magmom",
+    magforces_key="REF_magforces",
     head_key: str = "head",
 ) -> Tuple[SubsetCollection, Optional[Dict[int, float]]]:
     """
@@ -101,13 +102,15 @@ def get_dataset_from_xyz(
     for i, path in enumerate(train_paths):
         logging.debug("Loading training file: %s", path)
         logging.debug(
-            "Using keys: energy=%s, forces=%s, stress=%s, virials=%s, dipole=%s, charges=%s",
+            "Using keys: energy=%s, forces=%s, stress=%s, virials=%s, dipole=%s, charges=%s, magmom=%s, magforces_key=%s",
             energy_key,
             forces_key,
             stress_key,
             virials_key,
             dipole_key,
             charges_key,
+            magmom_key,
+            magforces_key,
         )
         ae_dict, train_configs = data.load_from_xyz(
             file_path=path,
@@ -118,6 +121,8 @@ def get_dataset_from_xyz(
             virials_key=virials_key,
             dipole_key=dipole_key,
             charges_key=charges_key,
+            magmom_key=magmom_key,
+            magforces_key=magforces_key,
             head_key=head_key,
             extract_atomic_energies=True,  # Extract from all files to average
             keep_isolated_atoms=keep_isolated_atoms,
@@ -162,6 +167,8 @@ def get_dataset_from_xyz(
                 virials_key=virials_key,
                 dipole_key=dipole_key,
                 charges_key=charges_key,
+                magmom_key=magmom_key,
+                magforces_key=magforces_key,
                 head_key=head_key,
                 extract_atomic_energies=False,
                 head_name=head_name,
@@ -196,7 +203,7 @@ def get_dataset_from_xyz(
             f"{np.sum([1 if getattr(config, 'forces', None) is not None else 0 for config in valid_configs])} forces, "
             f"{np.sum([1 if getattr(config, 'stress', None) is not None else 0 for config in valid_configs])} stresses]"
         )
-
+    
     # Process test files if provided
     test_configs_by_type = []
     if test_paths:
@@ -210,6 +217,8 @@ def get_dataset_from_xyz(
                 stress_key=stress_key,
                 virials_key=virials_key,
                 charges_key=charges_key,
+                magmom_key=magmom_key,
+                magforces_key=magforces_key,
                 head_key=head_key,
                 extract_atomic_energies=False,
                 head_name=head_name,

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -43,6 +43,7 @@ def get_dataset_from_xyz(
     energy_key: str = "REF_energy",
     forces_key: str = "REF_forces",
     stress_key: str = "REF_stress",
+    magforces_key="REF_magforces",
     virials_key: str = "virials",
     dipole_key: str = "dipoles",
     charges_key: str = "charges",

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -799,8 +799,7 @@ def get_params_options(
         else:
             no_decay_interactions[name] = param
 
-    param_options = dict(
-        params=[
+    params_list = [
             {
                 "name": "embedding",
                 "params": model.node_embedding.parameters(),
@@ -826,7 +825,35 @@ def get_params_options(
                 "params": model.readouts.parameters(),
                 "weight_decay": 0.0,
             },
-        ],
+        ]
+
+    if model.__class__.__name__ == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyReadoutSelfMagmomScaleShiftMACE" \
+        and args.train_one_body_contribution:
+            params_list.append({
+                "name": "magmom_exp_scaling_and_onebody_basis",
+                "params": [model.one_body_magmom_exp_scaling] + 
+                          list(model.onebody_magmombasis_list.parameters()),
+                "weight_decay": 0.0,
+            })
+
+    if model.__class__.__name__ == "MagneticSolidHarmonicsSpinOrbitCoupledWithOneBodyGinzburgSelfMagmomScaleShiftMACE" \
+        and args.train_one_body_contribution:
+            params_list.append({
+                "name": "magmom_exp_scaling_and_onebody_basis",
+                "params": [model.one_body_magmom_exp_scaling] + 
+                          list(model.onebody_magmombasis_list.parameters()),
+                "weight_decay": 0.0,
+            })
+            # params_list.append({
+            #     "name": "Ginzburg_coeffs",
+            #     "params": [model.Ginzburg_Landau_coeffs,],
+            #     "weight_decay": 0.0,
+            # })
+            
+
+    logging.info("params_list:", params_list)
+    param_options = dict(
+        params=params_list,
         lr=args.lr,
         amsgrad=args.amsgrad,
         betas=(args.beta, 0.999),

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -352,8 +352,12 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
         max_m_ell = None
 
     ##
-    print("mlp_irreps: ", mlp_irreps)
-    
+    radial_MLP = None
+    if hasattr(model.interactions[0], "conv_tp_weights"):
+        radial_MLP = model.interactions[0].conv_tp_weights.hs[1:-1]
+    else:
+        radial_MLP = model.interactions[0].conv_tp_m_weights.hs[1:-1]
+
     config = {
         "r_max": model.r_max.item(),
         "num_bessel": len(model.radial_embedding.bessel_fn.bessel_weights),
@@ -379,7 +383,7 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
         "radial_type": radial_to_name(
             model.radial_embedding.bessel_fn.__class__.__name__
         ),
-        "radial_MLP": model.interactions[0].conv_tp_weights.hs[1:-1],
+        "radial_MLP": radial_MLP, #model.interactions[0].conv_tp_weights.hs[1:-1] if 
         "pair_repulsion": hasattr(model, "pair_repulsion_fn"),
         "distance_transform": radial_to_transform(model.radial_embedding),
         "atomic_inter_scale": scale.cpu().numpy(),
@@ -389,10 +393,11 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
         "m_max": m_max,
         "num_mag_radial_basis": num_mag_radial_basis,
         "max_m_ell": max_m_ell,
-        "num_mag_radial_basis_one_body": int(model.onebody_magmombasis_coeffs.shape[1]),
         "contraction_cls": "SymmetricContraction",
         "contraction_cls_first": "SymmetricContraction",
     }
+    if hasattr(model, "onebody_magmombasis_coeffs"):
+        config["num_mag_radial_basis_one_body"] = int(model.onebody_magmombasis_coeffs.shape[1])
     return config
 
 

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -711,6 +711,10 @@ def get_loss_fn(
             forces_weight=args.forces_weight,
             dipole_weight=args.dipole_weight,
         )
+    elif args.loss == "EvenSpline1BodyLoss":
+        loss_fn = modules.EvenSpline1BodyLoss(
+            lambda_smooth = 3e-1,
+        )
     else:
         loss_fn = modules.WeightedEnergyForcesLoss(energy_weight=1.0, forces_weight=1.0)
     return loss_fn
@@ -850,11 +854,13 @@ def get_params_options(
                           list(model.onebody_magmombasis_list.parameters()),
                 "weight_decay": 0.0,
             })
-            # params_list.append({
-            #     "name": "Ginzburg_coeffs",
-            #     "params": [model.Ginzburg_Landau_coeffs,],
-            #     "weight_decay": 0.0,
-            # })
+
+    if "EvenSpline" in model.__class__.__name__ and args.train_one_body_contribution:
+            params_list.append({
+                "name": "E_m_spline.y",
+                "params": list(model.E_m_spline.y),
+                "weight_decay": 0.0,
+            })
             
 
     logging.info("params_list:", params_list)

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -389,6 +389,7 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
         "m_max": m_max,
         "num_mag_radial_basis": num_mag_radial_basis,
         "max_m_ell": max_m_ell,
+        "num_mag_radial_basis_one_body": int(model.onebody_magmombasis_coeffs.shape[1]),
         "contraction_cls": "SymmetricContraction",
         "contraction_cls_first": "SymmetricContraction",
     }

--- a/mace/tools/slurm_distributed.py
+++ b/mace/tools/slurm_distributed.py
@@ -19,19 +19,45 @@ class DistributedEnvironment:
         self.local_rank = int(os.environ["LOCAL_RANK"])
         self.rank = int(os.environ["RANK"])
 
+    # def _setup_distr_env(self):
+    #     hostname = hostlist.expand_hostlist(os.environ.get("SLURM_JOB_NODELIST", "localhost"))[0]
+    #     os.environ["MASTER_ADDR"] = hostname
+    #     os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "33333")
+    #     os.environ["WORLD_SIZE"] = os.environ.get(
+    #         "SLURM_NTASKS",
+    #         str(
+    #             int(os.environ["SLURM_NTASKS_PER_NODE"])
+    #             * int(os.environ["SLURM_NNODES"])
+    #         ),
+    #     )
+    #     os.environ["LOCAL_RANK"] = os.environ["SLURM_LOCALID"]
+    #     os.environ["RANK"] = os.environ["SLURM_PROCID"]
+
     def _setup_distr_env(self):
-        hostname = hostlist.expand_hostlist(os.environ["SLURM_JOB_NODELIST"])[0]
+        # Use SLURM job nodelist if available, otherwise default to localhost
+        hostname = hostlist.expand_hostlist(
+            os.environ.get("SLURM_JOB_NODELIST", "localhost")
+        )[0]
         os.environ["MASTER_ADDR"] = hostname
         os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "33333")
-        os.environ["WORLD_SIZE"] = os.environ.get(
-            "SLURM_NTASKS",
-            str(
-                int(os.environ["SLURM_NTASKS_PER_NODE"])
-                * int(os.environ["SLURM_NNODES"])
-            ),
-        )
-        os.environ["LOCAL_RANK"] = os.environ["SLURM_LOCALID"]
-        os.environ["RANK"] = os.environ["SLURM_PROCID"]
+
+        # WORLD_SIZE
+        if "SLURM_NTASKS" in os.environ:
+            os.environ["WORLD_SIZE"] = os.environ["SLURM_NTASKS"]
+        elif "WORLD_SIZE" not in os.environ:
+            os.environ["WORLD_SIZE"] = "1"
+
+        # LOCAL_RANK
+        if "SLURM_LOCALID" in os.environ:
+            os.environ["LOCAL_RANK"] = os.environ["SLURM_LOCALID"]
+        elif "LOCAL_RANK" not in os.environ:
+            os.environ["LOCAL_RANK"] = "0"
+
+        # RANK
+        if "SLURM_PROCID" in os.environ:
+            os.environ["RANK"] = os.environ["SLURM_PROCID"]
+        elif "RANK" not in os.environ:
+            os.environ["RANK"] = "0"
 
     def __repr__(self):
         return (

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -73,9 +73,12 @@ def valid_err_log(
         error_e = eval_metrics["rmse_e_per_atom"] * 1e3
         error_f = eval_metrics["rmse_f"] * 1e3
         error_stress = eval_metrics["rmse_stress"] * 1e3
-        logging.info(
-            f"{inintial_phrase}: head: {valid_loader_name}, loss={valid_loss:8.8f}, RMSE_E_per_atom={error_e:8.2f} meV, RMSE_F={error_f:8.2f} meV / A, RMSE_stress={error_stress:8.2f} meV / A^3",
-        )
+        errors_magforces = None
+        if 'rmse_magf' in eval_metrics.keys():
+            errors_magforces = eval_metrics['rmse_magf']
+        msg = f"{inintial_phrase}: head: {valid_loader_name}, loss={valid_loss:8.8f}, RMSE_E_per_atom={error_e:8.2f} meV, RMSE_F={error_f:8.2f} meV / A, RMSE_stress={error_stress:8.2f} meV / A^3"
+        msg += f", RMSE_magforces={errors_magforces:8.2f} μB / A" if errors_magforces is not None else ""
+        logging.info(msg)
     elif (
         log_errors == "PerAtomRMSEstressvirials"
         and eval_metrics["rmse_virials_per_atom"] is not None
@@ -191,6 +194,7 @@ def train(
             output_args=output_args,
             device=device,
         )
+        print(eval_metrics.keys())
         valid_err_log(
             valid_loss_head, eval_metrics, logger, log_errors, None, valid_loader_name
         )
@@ -585,6 +589,11 @@ class MACELoss(Metric):
         self.add_state("delta_mus", default=[], dist_reduce_fx="cat")
         self.add_state("delta_mus_per_atom", default=[], dist_reduce_fx="cat")
 
+        self.add_state("MagFs_computed", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("MagFs", default=[], dist_reduce_fx="cat")
+        self.add_state("delta_MagFs", default=[], dist_reduce_fx="cat")
+        
+
     def update(self, batch, output):  # pylint: disable=arguments-differ
         loss = self.loss_fn(pred=output, ref=batch)
         self.total_loss += loss
@@ -600,6 +609,10 @@ class MACELoss(Metric):
             self.Fs_computed += 1.0
             self.fs.append(batch.forces)
             self.delta_fs.append(batch.forces - output["forces"])
+        if output.get("magforces") is not None and batch.magforces is not None:
+            self.MagFs_computed += 1.0
+            self.MagFs.append(batch.magforces)
+            self.delta_MagFs.append(batch.magforces - output["magforces"])
         if output.get("stress") is not None and batch.stress is not None:
             self.stress_computed += 1.0
             self.delta_stress.append(batch.stress - output["stress"])
@@ -643,6 +656,14 @@ class MACELoss(Metric):
             aux["rmse_f"] = compute_rmse(delta_fs)
             aux["rel_rmse_f"] = compute_rel_rmse(delta_fs, fs)
             aux["q95_f"] = compute_q95(delta_fs)
+        if self.MagFs_computed:
+            MagFs = self.convert(self.MagFs)
+            delta_MagFs = self.convert(self.delta_MagFs)
+            aux["mae_magf"] = compute_mae(delta_MagFs)
+            aux["rel_mae_magf"] = compute_rel_mae(delta_MagFs, MagFs)
+            aux["rmse_magf"] = compute_rmse(delta_MagFs)
+            aux["rel_rmse_magf"] = compute_rel_rmse(delta_MagFs, MagFs)
+            aux["q95_magf"] = compute_q95(delta_MagFs)
         if self.stress_computed:
             delta_stress = self.convert(self.delta_stress)
             aux["mae_stress"] = compute_mae(delta_stress)

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -409,6 +409,7 @@ def take_step(
             compute_force=output_args["forces"],
             compute_virials=output_args["virials"],
             compute_stress=output_args["stress"],
+            compute_magforces=output_args["magforces"]
         )
         loss = loss_fn(pred=output, ref=batch)
         loss.backward()

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -167,6 +167,7 @@ def train(
     distributed_model: Optional[DistributedDataParallel] = None,
     train_sampler: Optional[DistributedSampler] = None,
     rank: Optional[int] = 0,
+    data_aug_magmom: Optional[bool] = False,
 ):
     lowest_loss = np.inf
     valid_loss = np.inf
@@ -223,6 +224,12 @@ def train(
             train_sampler.set_epoch(epoch)
         if "ScheduleFree" in type(optimizer).__name__:
             optimizer.train()
+
+        # fix training loader here with 
+        if data_aug_magmom:
+            from mace.data import create_random_rotation_loader
+            train_loader = create_random_rotation_loader(train_loader)
+
         train_one_epoch(
             model=model,
             loss_fn=loss_fn,

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -75,9 +75,9 @@ def valid_err_log(
         error_stress = eval_metrics["rmse_stress"] * 1e3
         errors_magforces = None
         if 'rmse_magf' in eval_metrics.keys():
-            errors_magforces = eval_metrics['rmse_magf']
+            errors_magforces = eval_metrics['rmse_magf'] * 1e3
         msg = f"{inintial_phrase}: head: {valid_loader_name}, loss={valid_loss:8.8f}, RMSE_E_per_atom={error_e:8.2f} meV, RMSE_F={error_f:8.2f} meV / A, RMSE_stress={error_stress:8.2f} meV / A^3"
-        msg += f", RMSE_magforces={errors_magforces:8.2f} μB / A" if errors_magforces is not None else ""
+        msg += f", RMSE_magforces={errors_magforces:8.2f} meV / μB" if errors_magforces is not None else ""
         logging.info(msg)
     elif (
         log_errors == "PerAtomRMSEstressvirials"

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -547,6 +547,7 @@ def evaluate(
             compute_stress=output_args["stress"],
         )
         avg_loss, aux = metrics(batch, output)
+        print("avg_loss:", avg_loss)
 
     avg_loss, aux = metrics.compute()
     aux["time"] = time.time() - start_time

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -227,8 +227,20 @@ def train(
 
         # fix training loader here with 
         if data_aug_magmom:
-            from mace.data import create_random_rotation_loader
-            train_loader = create_random_rotation_loader(train_loader)
+            from mace.data import create_random_rotation_dataset
+            # Avoid stacking transforms
+            if not 'TransformedDataset' == type(train_loader.dataset).__name__:
+                dataset_aug = create_random_rotation_dataset(train_loader.dataset)
+
+                # Rebuild loader from dataset
+                train_loader = torch.utils.data.DataLoader(
+                    dataset_aug,
+                    batch_size=train_loader.batch_size,
+                    shuffle=True,
+                    num_workers=train_loader.num_workers,
+                    pin_memory=True,
+                    collate_fn=train_loader.collate_fn,
+                )
 
         train_one_epoch(
             model=model,


### PR DESCRIPTION
## Summary
- switch the default non-SOC contraction path to the optimized implementation while keeping reference and sparse paths available for validation
- add a shape-aware fix for the legacy non-SOC magnetic TP weight reshape so L>0 configurations no longer fail immediately in the interaction block
- suppress noisy `cuequivariance_torch` tensor-product debug logs at import time
- add reusable non-SOC smoke/benchmark scripts under `benchmarks/nonSOC`

## Validation
- compared trained non-SOC model outputs between `reference` and `optimized` on CUDA for 10 validation structures; energies, forces, and stress matched to numerical precision
- benchmarked the trained non-SOC model contraction modules on CUDA with `batch_size=64`, `warmup=20`, `repeat=200`
  - reference: ~3.05 ms
  - optimized: ~1.58 ms
  - sparse: ~2.96 ms
- ran the non-SOC hidden-irreps sweep benchmark for the requested model and interaction classes
  - L=0 runs were healthy and `optimized` was faster than `reference`
  - L=1 now initializes and runs for `reference`/`optimized`; sparse currently OOMs and is not the default path

## Notes
- the sparse contraction path remains available for experimentation/validation but is not the runtime default
- benchmark scripts live in `benchmarks/nonSOC/` for local follow-up