### PR TITLE
Fix foundation fine-tuning replay and magnetic inheritance

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -33,7 +33,9 @@ from mace.tools.multihead_tools import (
     HeadConfig,
     assemble_mp_data,
     dict_head_to_dataclass,
+    inherit_magnetic_hyperparameters_from_foundation,
     prepare_default_head,
+    prepare_custom_pt_head,
 )
 from mace.tools.run_train_utils import (
     combine_datasets,
@@ -154,6 +156,14 @@ def run(args) -> None:
                 f"Using foundation model {args.foundation_model} as initial checkpoint."
             )
         args.r_max = model_foundation.r_max.item()
+        inherited_magnetic_args = inherit_magnetic_hyperparameters_from_foundation(
+            args, model_foundation
+        )
+
+        if inherited_magnetic_args:
+            logging.info(
+                f"Inheriting magnetic hyperparameters from foundation model: {inherited_magnetic_args}"
+            )
         if (
             args.foundation_model not in ["small", "medium", "large"]
             and args.pt_train_file is None
@@ -332,79 +342,10 @@ def run(args) -> None:
                 f"Using foundation model for multiheads finetuning with {args.pt_train_file}"
             )
             heads = list(dict.fromkeys(["pt_head"] + heads))
-
-            # Use pt-specific keys if provided, otherwise fall back to general keys
-            pt_energy_key = args.pt_energy_key or args.energy_key
-            pt_forces_key = args.pt_forces_key or args.forces_key
-            pt_stress_key = args.pt_stress_key or args.stress_key
-            pt_virials_key = args.pt_virials_key or args.virials_key
-            pt_dipole_key = args.pt_dipole_key or args.dipole_key
-            pt_charges_key = args.pt_charges_key or args.charges_key
-            pt_magmom_key = args.pt_magmom_key or args.magmom_key
-
-            logging.info(
-                f"Using the following keys for pt_head: energy={pt_energy_key}, forces={pt_forces_key}, "
-                f"stress={pt_stress_key}, virials={pt_virials_key}, dipole={pt_dipole_key}, charges={pt_charges_key}, magmom={pt_magmom_key}"
-            )
-
-            # Normalize file paths
-            pt_train_file = normalize_file_paths(args.pt_train_file)
-            pt_valid_file = (
-                normalize_file_paths(args.pt_valid_file) if args.pt_valid_file else None
-            )
-
-            # Check if pt_train_file is ASE readable (e.g., xyz) vs LMDB/HDF5
-            is_ase_readable = all(check_path_ase_read(f) for f in pt_train_file)
-
-            head_config_pt = HeadConfig(
-                head_name="pt_head",
-                train_file=pt_train_file,
-                valid_file=pt_valid_file,
-                E0s="foundation",
-                statistics_file=args.statistics_file,
-                valid_fraction=args.valid_fraction,
-                config_type_weights=None,
-                energy_key=pt_energy_key,
-                forces_key=pt_forces_key,
-                stress_key=pt_stress_key,
-                virials_key=pt_virials_key,
-                dipole_key=pt_dipole_key,
-                charges_key=pt_charges_key,
-                magmom_key=pt_magmom_key,
-                keep_isolated_atoms=args.keep_isolated_atoms,
+            head_config_pt = prepare_custom_pt_head(
+                args=args,
                 avg_num_neighbors=model_foundation.interactions[0].avg_num_neighbors,
-                compute_avg_num_neighbors=False,
             )
-
-            if is_ase_readable:
-                # For xyz files, use get_dataset_from_xyz
-                collections, atomic_energies_dict = get_dataset_from_xyz(
-                    work_dir=args.work_dir,
-                    train_path=args.pt_train_file,
-                    valid_path=args.pt_valid_file,
-                    valid_fraction=args.valid_fraction,
-                    config_type_weights=None,
-                    test_path=None,
-                    seed=args.seed,
-                    energy_key=pt_energy_key,
-                    forces_key=pt_forces_key,
-                    stress_key=pt_stress_key,
-                    virials_key=pt_virials_key,
-                    dipole_key=pt_dipole_key,
-                    charges_key=pt_charges_key,
-                    magmom_key=pt_magmom_key,
-                    head_name="pt_head",
-                    keep_isolated_atoms=args.keep_isolated_atoms,
-                )
-                head_config_pt.collections = collections
-                logging.info(
-                    f"Loaded ASE readable pretraining data: train={len(collections.train)}, valid={len(collections.valid)}"
-                )
-            else:
-                logging.info(
-                    f"Pretraining data file(s) will be loaded as LMDB/HDF5: {pt_train_file}"
-                )
-
             head_configs.append(head_config_pt)
 
         all_ase_readable = all(
@@ -500,21 +441,22 @@ def run(args) -> None:
         assert (
             model_foundation is not None
         ), "Model foundation must be provided for multiheads finetuning"
-        z_table_foundation = AtomicNumberTable(
-            [int(z) for z in model_foundation.atomic_numbers]
-        )
-        foundation_atomic_energies = model_foundation.atomic_energies_fn.atomic_energies
-        if foundation_atomic_energies.ndim > 1:
-            foundation_atomic_energies = foundation_atomic_energies.squeeze()
-            if foundation_atomic_energies.ndim == 2:
-                foundation_atomic_energies = foundation_atomic_energies[0]
-                logging.info("Foundation model has multiple heads, using the first head as foundation E0s.")
-        atomic_energies_dict["pt_head"] = {
-            z: foundation_atomic_energies[
-                z_table_foundation.z_to_index(z)
-            ].item()
-            for z in z_table.zs
-        }
+        if "pt_head" not in atomic_energies_dict or not atomic_energies_dict["pt_head"]:
+            z_table_foundation = AtomicNumberTable(
+                [int(z) for z in model_foundation.atomic_numbers]
+            )
+            foundation_atomic_energies = model_foundation.atomic_energies_fn.atomic_energies
+            if foundation_atomic_energies.ndim > 1:
+                foundation_atomic_energies = foundation_atomic_energies.squeeze()
+                if foundation_atomic_energies.ndim == 2:
+                    foundation_atomic_energies = foundation_atomic_energies[0]
+                    logging.info("Foundation model has multiple heads, using the first head as foundation E0s.")
+            atomic_energies_dict["pt_head"] = {
+                z: foundation_atomic_energies[
+                    z_table_foundation.z_to_index(z)
+                ].item()
+                for z in z_table.zs
+            }
 
     # Padding atomic energies if keeping all elements of the foundation model
     if args.foundation_model_elements and model_foundation:

--- a/mace/tools/multihead_tools.py
+++ b/mace/tools/multihead_tools.py
@@ -9,10 +9,13 @@ from typing import Any, Dict, List, Optional, Union
 import torch
 
 from mace.cli.fine_tuning_select import select_samples
+from mace.tools.run_train_utils import normalize_file_paths
 from mace.tools.scripts_utils import (
     SubsetCollection,
     dict_to_namespace,
+    extract_config_mace_model,
     get_dataset_from_xyz,
+    check_path_ase_read,
 )
 
 
@@ -201,3 +204,121 @@ def assemble_mp_data(
         raise RuntimeError(
             "Model or descriptors download failed and no local model found"
         ) from exc
+
+
+def prepare_custom_pt_head(
+    args: argparse.Namespace,
+    avg_num_neighbors: float,
+) -> HeadConfig:
+    r"""Prepare the replay head used for multihead fine-tuning with a custom foundation model."""
+    pt_energy_key = args.pt_energy_key or args.energy_key
+    pt_forces_key = args.pt_forces_key or args.forces_key
+    pt_stress_key = args.pt_stress_key or args.stress_key
+    pt_virials_key = args.pt_virials_key or args.virials_key
+    pt_dipole_key = args.pt_dipole_key or args.dipole_key
+    pt_charges_key = args.pt_charges_key or args.charges_key
+    pt_magmom_key = args.pt_magmom_key or args.magmom_key
+
+    logging.info(
+        f"Using the following keys for pt_head: energy={pt_energy_key}, forces={pt_forces_key}, "
+        f"stress={pt_stress_key}, virials={pt_virials_key}, dipole={pt_dipole_key}, charges={pt_charges_key}, magmom={pt_magmom_key}"
+    )
+
+    pt_train_file = normalize_file_paths(args.pt_train_file)
+    pt_valid_file = normalize_file_paths(args.pt_valid_file) if args.pt_valid_file else None
+    is_ase_readable = all(check_path_ase_read(f) for f in pt_train_file)
+
+    head_config_pt = HeadConfig(
+        head_name="pt_head",
+        train_file=pt_train_file,
+        valid_file=pt_valid_file,
+        E0s="foundation",
+        statistics_file=args.statistics_file,
+        valid_fraction=args.valid_fraction,
+        config_type_weights=None,
+        energy_key=pt_energy_key,
+        forces_key=pt_forces_key,
+        stress_key=pt_stress_key,
+        virials_key=pt_virials_key,
+        dipole_key=pt_dipole_key,
+        charges_key=pt_charges_key,
+        magmom_key=pt_magmom_key,
+        keep_isolated_atoms=args.keep_isolated_atoms,
+        avg_num_neighbors=avg_num_neighbors,
+        compute_avg_num_neighbors=False,
+    )
+
+    if is_ase_readable:
+        collections, atomic_energies_dict = get_dataset_from_xyz(
+            work_dir=args.work_dir,
+            train_path=args.pt_train_file,
+            valid_path=args.pt_valid_file,
+            valid_fraction=args.valid_fraction,
+            config_type_weights=None,
+            test_path=None,
+            seed=args.seed,
+            energy_key=pt_energy_key,
+            forces_key=pt_forces_key,
+            stress_key=pt_stress_key,
+            virials_key=pt_virials_key,
+            dipole_key=pt_dipole_key,
+            charges_key=pt_charges_key,
+            magmom_key=pt_magmom_key,
+            head_name="pt_head",
+            keep_isolated_atoms=args.keep_isolated_atoms,
+        )
+        head_config_pt.collections = collections
+        if atomic_energies_dict:
+            head_config_pt.atomic_energies_dict = atomic_energies_dict
+            logging.info(
+                "Using atomic energies inferred from pt_train_file isolated atoms for pt_head."
+            )
+        logging.info(
+            f"Loaded ASE readable pretraining data: train={len(collections.train)}, valid={len(collections.valid)}"
+        )
+    else:
+        logging.info(
+            f"Pretraining data file(s) will be loaded as LMDB/HDF5: {pt_train_file}"
+        )
+
+    return head_config_pt
+
+
+def inherit_magnetic_hyperparameters_from_foundation(
+    args: argparse.Namespace, model_foundation: torch.nn.Module
+) -> Dict[str, Any]:
+    r"""Copy magnetic basis hyperparameters from the foundation checkpoint onto args."""
+    foundation_config = extract_config_mace_model(model_foundation)
+    inherited_magnetic_args: Dict[str, Any] = {}
+
+    foundation_m_max = foundation_config.get("m_max")
+    if foundation_m_max is not None:
+        if torch.is_tensor(foundation_m_max):
+            foundation_m_max = foundation_m_max.detach().cpu().tolist()
+        elif hasattr(foundation_m_max, "tolist"):
+            foundation_m_max = foundation_m_max.tolist()
+        args.m_max = foundation_m_max
+        inherited_magnetic_args["m_max_len"] = len(foundation_m_max)
+
+    foundation_max_m_ell = foundation_config.get("max_m_ell")
+    if foundation_max_m_ell is not None:
+        args.max_m_ell = int(foundation_max_m_ell)
+        inherited_magnetic_args["max_m_ell"] = args.max_m_ell
+
+    foundation_num_mag_radial_basis = foundation_config.get("num_mag_radial_basis")
+    if foundation_num_mag_radial_basis is not None:
+        args.num_mag_radial_basis = int(foundation_num_mag_radial_basis)
+        inherited_magnetic_args["num_mag_radial_basis"] = args.num_mag_radial_basis
+
+    foundation_num_mag_radial_basis_one_body = foundation_config.get(
+        "num_mag_radial_basis_one_body"
+    )
+    if foundation_num_mag_radial_basis_one_body is not None:
+        args.num_mag_radial_basis_one_body = int(
+            foundation_num_mag_radial_basis_one_body
+        )
+        inherited_magnetic_args["num_mag_radial_basis_one_body"] = (
+            args.num_mag_radial_basis_one_body
+        )
+
+    return inherited_magnetic_args

--- a/tests/test_run_train.py
+++ b/tests/test_run_train.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import ase.io
 import numpy as np
@@ -11,6 +12,10 @@ import torch
 from ase.atoms import Atoms
 
 from mace.calculators import MACECalculator, mace_mp
+from mace.tools.multihead_tools import (
+    inherit_magnetic_hyperparameters_from_foundation,
+    prepare_custom_pt_head,
+)
 
 try:
     import cuequivariance as cue  # pylint: disable=unused-import
@@ -854,6 +859,81 @@ def test_run_train_multihead_replay_custum_finetuning(
     assert len(Es) == len(fitting_configs)
     assert all(isinstance(E, float) for E in Es)
     assert len(set(Es)) > 1  # Ens
+
+
+def test_run_train_foundation_multihead_custom_pt_e0s_override(
+    tmp_path, pretraining_configs
+):
+    torch.set_default_dtype(torch.float64)
+
+    ase.io.write(tmp_path / "pretrain.xyz", pretraining_configs)
+    args = SimpleNamespace(
+        work_dir=str(tmp_path),
+        seed=42,
+        valid_fraction=0.1,
+        energy_key="REF_energy",
+        forces_key="REF_forces",
+        stress_key="REF_stress",
+        virials_key="REF_virials",
+        dipole_key="REF_dipole",
+        charges_key="REF_charges",
+        magmom_key="REF_magmom",
+        magforces_key="REF_magforces",
+        pt_energy_key=None,
+        pt_forces_key=None,
+        pt_stress_key=None,
+        pt_virials_key=None,
+        pt_dipole_key=None,
+        pt_charges_key=None,
+        pt_magmom_key=None,
+        keep_isolated_atoms=True,
+        statistics_file=None,
+        pt_train_file=str(tmp_path / "pretrain.xyz"),
+        pt_valid_file=None,
+    )
+
+    head_config_pt = prepare_custom_pt_head(args, avg_num_neighbors=1.0)
+
+    assert head_config_pt.head_name == "pt_head"
+    assert head_config_pt.E0s == "foundation"
+    assert head_config_pt.atomic_energies_dict is not None
+    assert np.isclose(head_config_pt.atomic_energies_dict[1], -4.0)
+    assert np.isclose(head_config_pt.atomic_energies_dict[8], -2.0)
+
+
+def test_run_train_foundation_multihead_inherits_magnetic_hyperparameters(monkeypatch):
+    args = SimpleNamespace(
+        m_max=[1, 1, 1],
+        max_m_ell=1,
+        num_mag_radial_basis=1,
+        num_mag_radial_basis_one_body=1,
+    )
+    foundation_config = {
+        "m_max": torch.tensor([2, 3, 4], dtype=torch.int64),
+        "max_m_ell": 5,
+        "num_mag_radial_basis": 6,
+        "num_mag_radial_basis_one_body": 7,
+    }
+
+    monkeypatch.setattr(
+        "mace.tools.multihead_tools.extract_config_mace_model",
+        lambda model: foundation_config,
+    )
+
+    inherited = inherit_magnetic_hyperparameters_from_foundation(
+        args, object()
+    )
+
+    assert args.m_max == [2, 3, 4]
+    assert args.max_m_ell == 5
+    assert args.num_mag_radial_basis == 6
+    assert args.num_mag_radial_basis_one_body == 7
+    assert inherited == {
+        "m_max_len": 3,
+        "max_m_ell": 5,
+        "num_mag_radial_basis": 6,
+        "num_mag_radial_basis_one_body": 7,
+    }
 
 
 @pytest.mark.skipif(not CUET_AVAILABLE, reason="cuequivariance not installed")


### PR DESCRIPTION
This PR fixes the fine-tuning path for foundation-model multihead replay.

Changes:
- Reuse the original multihead replay-head construction for custom foundation fine-tuning.
- Preserve replay atomic energies from the pretraining data when available.
- Automatically inherit magnetic hyperparameters from the foundation checkpoint (`m_max`, `max_m_ell`, `num_mag_radial_basis`, `num_mag_radial_basis_one_body`).
- Add focused regressions for replay E0 override and magnetic hyperparameter inheritance.

Validation:
- `python -m py_compile mace/cli/run_train.py mace/tools/multihead_tools.py tests/test_run_train.py`
- `pytest -q tests/test_run_train.py -k 'custom_pt_e0s_override or magnetic_hyperparameters'`

Opened as draft for review.