### PR TITLE
Add PBC MM-subtracted electrostatic accounting

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -181,6 +181,7 @@ class MACECalculator(Calculator):
             )
             if model_type == "PolarMACE":
                 self.implemented_properties.append("ml_mm_electrostatic_energy")
+                self.implemented_properties.append("mm_mm_electrostatic_energy")
             if kwargs.get("compute_atomic_stresses", False):
                 self.implemented_properties.extend(["stresses", "virials"])
                 self.compute_atomic_stresses = True
@@ -401,6 +402,7 @@ class MACECalculator(Calculator):
                     "electrostatic_energy": [],
                     "ml_mm_electrostatic_energy": [],
                     "ml_mm_dipole_energy": [],
+                    "mm_mm_electrostatic_energy": [],
                     "electron_energy": [],
                     "spins": [num_atoms],
                     "density_coefficients": [num_atoms, self.density_dim],
@@ -551,6 +553,11 @@ class MACECalculator(Calculator):
                     (
                         "ml_mm_dipole_energy",
                         "ml_mm_dipole_energy",
+                        self.energy_units_to_eV,
+                    ),
+                    (
+                        "mm_mm_electrostatic_energy",
+                        "mm_mm_electrostatic_energy",
                         self.energy_units_to_eV,
                     ),
                     ("electron_energy", "electron_energy", self.energy_units_to_eV),

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -921,6 +921,8 @@ class PolarMACE(ScaleShiftMACE):
         mm_positions: Optional[torch.Tensor],
         mm_batch: Optional[torch.Tensor],
         num_graphs: int,
+        cell: Optional[torch.Tensor] = None,
+        pbc: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if mm_positions is None or mm_charges is None:
             zeros = torch.zeros(
@@ -945,8 +947,15 @@ class PolarMACE(ScaleShiftMACE):
         # Coulomb prefactor (eV·Å)
         k_e = 14.3996454784255
 
-        # pairwise distances
-        rij = ml_positions[:, None, :] - mm_positions[None, :, :]
+        rij = self._ml_mm_displacements(
+            ml_positions=ml_positions,
+            ml_batch=ml_batch,
+            mm_positions=mm_positions,
+            mm_batch=mm_batch,
+            num_graphs=num_graphs,
+            cell=cell,
+            pbc=pbc,
+        )
         r = torch.linalg.norm(rij, dim=-1).clamp_min(1e-6)
 
         qi = ml_charges[:, None]
@@ -976,6 +985,59 @@ class PolarMACE(ScaleShiftMACE):
             )
 
         return monopole_graph + dipole_graph, dipole_graph
+
+    @staticmethod
+    def _ml_mm_displacements(
+        ml_positions: torch.Tensor,
+        ml_batch: torch.Tensor,
+        mm_positions: torch.Tensor,
+        mm_batch: torch.Tensor,
+        num_graphs: int,
+        cell: Optional[torch.Tensor],
+        pbc: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Return ML-MM displacement vectors, with minimum-image PBC if requested."""
+        rij = ml_positions[:, None, :] - mm_positions[None, :, :]
+        if cell is None or pbc is None or not torch.any(pbc):
+            return rij
+
+        cell_mats = cell.view(-1, 3, 3).to(device=ml_positions.device, dtype=ml_positions.dtype)
+        pbc_flags = pbc.view(-1, 3).to(device=ml_positions.device)
+        rij_pbc = rij.clone()
+        for graph_index in range(num_graphs):
+            periodic_dims = pbc_flags[graph_index]
+            if not torch.any(periodic_dims):
+                continue
+            ml_mask = ml_batch == graph_index
+            mm_mask = mm_batch == graph_index
+            if not torch.any(ml_mask) or not torch.any(mm_mask):
+                continue
+            disp = rij_pbc[ml_mask][:, mm_mask, :]
+            frac = torch.matmul(disp, torch.linalg.inv(cell_mats[graph_index]))
+            frac = frac.clone()
+            frac[..., periodic_dims] = frac[..., periodic_dims] - torch.round(
+                frac[..., periodic_dims]
+            )
+            rij_pbc[ml_mask[:, None] & mm_mask[None, :]] = torch.matmul(
+                frac, cell_mats[graph_index]
+            ).reshape(-1, 3)
+        return rij_pbc
+
+    @staticmethod
+    def _mm_charge_features(
+        mm_charges: torch.Tensor,
+        feature_dim: int,
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Represent MM point charges as l=0-only electrostatic source features."""
+        mm_features = torch.zeros(
+            (mm_charges.numel(), feature_dim), dtype=dtype, device=device
+        )
+        if mm_features.numel() > 0:
+            mm_features[:, 0] = mm_charges.to(device=device, dtype=dtype).reshape(-1)
+        return mm_features
 
     def _extract_ml_dipoles(
         self, charge_density_mul_ir: torch.Tensor
@@ -1346,26 +1408,74 @@ class PolarMACE(ScaleShiftMACE):
         mm_positions = _get_optional_data_tensor(data, "mm_positions")
         mm_charges = _get_optional_data_tensor(data, "mm_charges")
         mm_source_batch = _get_optional_data_tensor(data, "mm_source_batch")
+        mm_mm_electrostatic_energy = torch.zeros_like(electro_energy)
         if not (mm_positions is None or mm_charges is None):
-            ml_charges = charge_density_mul_ir[:, 0]
-            ml_dipoles = self._extract_ml_dipoles(charge_density_mul_ir)
-            ml_mm_electrostatic_energy, ml_mm_dipole_energy = self._ml_mm_coulomb(
-                ml_charges,
-                ml_dipoles,
-                positions,
-                data["batch"],
-                mm_charges,
-                mm_positions_for_grad,
-                mm_source_batch,
-                num_graphs,
-            )
+            if mm_source_batch is None:
+                mm_source_batch = torch.zeros(
+                    mm_charges.numel(), dtype=torch.long, device=positions.device
+                )
+            else:
+                mm_source_batch = mm_source_batch.to(device=positions.device, dtype=torch.long).reshape(-1)
+
+            if torch.any(data["pbc"].view(-1, 3)):
+                mm_features = self._mm_charge_features(
+                    mm_charges,
+                    charge_density_mul_ir.shape[-1],
+                    dtype=charge_density_mul_ir.dtype,
+                    device=charge_density_mul_ir.device,
+                )
+                mixed_features = torch.cat((charge_density_mul_ir, mm_features), dim=0)
+                mixed_positions = torch.cat((positions, mm_positions_for_grad), dim=0)
+                mixed_batch = torch.cat((data["batch"], mm_source_batch), dim=0)
+                mixed_electrostatic_energy = self.coulomb_energy(
+                    k_vectors=k_vectors,
+                    k_norm2=kv_norms_squared,
+                    k_vector_batch=k_vectors_batch,
+                    k0_mask=k_vectors_0mask,
+                    source_feats=mixed_features,
+                    node_positions=mixed_positions,
+                    batch=mixed_batch,
+                    volume=data["volume"],
+                    pbc=data["pbc"].view(-1, 3),
+                    force_pbc_evaluator=use_pbc_evaluator,
+                )
+                mm_mm_electrostatic_energy = self.coulomb_energy(
+                    k_vectors=k_vectors,
+                    k_norm2=kv_norms_squared,
+                    k_vector_batch=k_vectors_batch,
+                    k0_mask=k_vectors_0mask,
+                    source_feats=mm_features,
+                    node_positions=mm_positions_for_grad,
+                    batch=mm_source_batch,
+                    volume=data["volume"],
+                    pbc=data["pbc"].view(-1, 3),
+                    force_pbc_evaluator=use_pbc_evaluator,
+                )
+                electro_energy = mixed_electrostatic_energy - mm_mm_electrostatic_energy
+                ml_mm_electrostatic_energy = electro_energy
+                ml_mm_dipole_energy = torch.zeros_like(electro_energy)
+            else:
+                ml_charges = charge_density_mul_ir[:, 0]
+                ml_dipoles = self._extract_ml_dipoles(charge_density_mul_ir)
+                ml_mm_electrostatic_energy, ml_mm_dipole_energy = self._ml_mm_coulomb(
+                    ml_charges,
+                    ml_dipoles,
+                    positions,
+                    data["batch"],
+                    mm_charges,
+                    mm_positions_for_grad,
+                    mm_source_batch,
+                    num_graphs,
+                    cell=cell,
+                    pbc=data["pbc"].view(-1, 3),
+                )
+                electro_energy = electro_energy + ml_mm_electrostatic_energy
         else:
             ml_mm_electrostatic_energy = torch.zeros_like(electro_energy)
             ml_mm_dipole_energy = torch.zeros_like(electro_energy)
         total_energy = (
             total_energy
             + electro_energy
-            + ml_mm_electrostatic_energy
             + torch.sum(external_potential[:, 1:] * total_dipole, dim=-1)
         )
 
@@ -1432,6 +1542,7 @@ class PolarMACE(ScaleShiftMACE):
             "electrostatic_energy": electro_energy,
             "ml_mm_electrostatic_energy": ml_mm_electrostatic_energy,
             "ml_mm_dipole_energy": ml_mm_dipole_energy,
+            "mm_mm_electrostatic_energy": mm_mm_electrostatic_energy,
             "electron_energy": le_total,
             "electrostatic_potentials": esps,
             "spin_charge_density": spin_charge_density_mul_ir,

--- a/tests/test_mm_field_routes.py
+++ b/tests/test_mm_field_routes.py
@@ -86,7 +86,7 @@ def _build_minimal_model(device, dtype):
     ).to(device=device, dtype=dtype)
 
 
-def _build_mm_batch(device, dtype, n_mm=8, seed=0):
+def _build_mm_batch(device, dtype, n_mm=8, seed=0, pbc=False):
     """A batched water-like 2-atom QM system + n_mm MM point charges.
 
     Layout matches the schema PolarMACE.forward expects: mm_positions,
@@ -114,6 +114,7 @@ def _build_mm_batch(device, dtype, n_mm=8, seed=0):
     rcell = torch.eye(3, dtype=dtype, device=device).unsqueeze(0) * (
         2.0 * math.pi / cell_len
     )
+    volume = torch.det(cell.view(1, 3, 3))
 
     # MM cloud placed in a 4-8 Å shell around the origin so it sits clearly
     # outside the 2-atom QM region.
@@ -135,8 +136,8 @@ def _build_mm_batch(device, dtype, n_mm=8, seed=0):
         "ptr": ptr,
         "cell": cell.view(-1, 9),
         "rcell": rcell.view(-1, 9),
-        "volume": torch.ones((1,), dtype=dtype, device=device),
-        "pbc": torch.zeros((1, 3), dtype=torch.bool, device=device),
+        "volume": volume,
+        "pbc": torch.full((1, 3), bool(pbc), dtype=torch.bool, device=device),
         "external_field": torch.zeros((1, 3), dtype=dtype, device=device),
         "fermi_level": torch.zeros((1,), dtype=dtype, device=device),
         "total_charge": torch.zeros((1,), dtype=dtype, device=device),
@@ -153,8 +154,10 @@ def _run_route(model, data, route: str) -> dict:
     out = model(data, training=False, compute_force=True)
     energy = out["energy"].detach().clone()
     forces = out["forces"].detach().clone()
+    electrostatic_energy = out["electrostatic_energy"].detach().clone()
     ml_mm_electrostatic_energy = out["ml_mm_electrostatic_energy"].detach().clone()
     ml_mm_dipole_energy = out["ml_mm_dipole_energy"].detach().clone()
+    mm_mm_electrostatic_energy = out["mm_mm_electrostatic_energy"].detach().clone()
     mm_forces = out["mm_forces"]
     assert mm_forces is not None, "expected mm_forces in output when MM input present"
     mm_forces = mm_forces.detach().clone()
@@ -163,9 +166,11 @@ def _run_route(model, data, route: str) -> dict:
     return {
         "energy": energy,
         "forces": forces,
+        "electrostatic_energy": electrostatic_energy,
         "mm_forces": mm_forces,
         "ml_mm_electrostatic_energy": ml_mm_electrostatic_energy,
         "ml_mm_dipole_energy": ml_mm_dipole_energy,
+        "mm_mm_electrostatic_energy": mm_mm_electrostatic_energy,
         "charges": charges,
         "density_coefficients": density_coefficients,
     }
@@ -293,3 +298,73 @@ def test_ml_mm_dipole_energy_matches_direct_pair_sum():
     torch.testing.assert_close(
         out["ml_mm_electrostatic_energy"], expected_total, atol=1e-9, rtol=1e-9
     )
+
+
+def test_mace_mm_embedding_reports_no_mm_mm_energy():
+    """MACE owns ML-MM Coulomb only; MM-MM Coulomb remains an OpenMM term."""
+    device = torch.device("cpu")
+    model = _build_minimal_model(device, torch.float64)
+    data = _build_mm_batch(device, torch.float64)
+    out = _run_route(model, data, "source_target")
+    torch.testing.assert_close(
+        out["mm_mm_electrostatic_energy"],
+        torch.zeros_like(out["mm_mm_electrostatic_energy"]),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+def test_pbc_mace_returns_mm_only_kspace_diagnostic():
+    """Under PBC, MACE returns E(ML+MM)-E(MM) and exposes E(MM)."""
+    device = torch.device("cpu")
+    model = _build_minimal_model(device, torch.float64)
+    data = _build_mm_batch(device, torch.float64, pbc=True)
+    out = _run_route(model, data, "source_target")
+    assert out["mm_mm_electrostatic_energy"].abs().max().item() > 1e-12
+    torch.testing.assert_close(
+        out["electrostatic_energy"],
+        out["ml_mm_electrostatic_energy"],
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+def test_ml_mm_coulomb_uses_minimum_image_under_pbc():
+    device = torch.device("cpu")
+    dtype = torch.float64
+    model = _build_minimal_model(device, dtype)
+    ml_positions = torch.tensor([[0.2, 0.0, 0.0]], device=device, dtype=dtype)
+    mm_positions = torch.tensor([[9.8, 0.0, 0.0]], device=device, dtype=dtype)
+    ml_charges = torch.tensor([1.0], device=device, dtype=dtype)
+    mm_charges = torch.tensor([1.0], device=device, dtype=dtype)
+    batch = torch.zeros(1, dtype=torch.long, device=device)
+    cell = torch.eye(3, dtype=dtype, device=device).unsqueeze(0) * 10.0
+    pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+
+    energy_pbc, _ = model._ml_mm_coulomb(
+        ml_charges=ml_charges,
+        ml_dipoles=None,
+        ml_positions=ml_positions,
+        ml_batch=batch,
+        mm_charges=mm_charges,
+        mm_positions=mm_positions,
+        mm_batch=batch,
+        num_graphs=1,
+        cell=cell,
+        pbc=pbc,
+    )
+    energy_nonpbc, _ = model._ml_mm_coulomb(
+        ml_charges=ml_charges,
+        ml_dipoles=None,
+        ml_positions=ml_positions,
+        ml_batch=batch,
+        mm_charges=mm_charges,
+        mm_positions=mm_positions,
+        mm_batch=batch,
+        num_graphs=1,
+    )
+
+    expected_pbc = torch.tensor([14.3996454784255 / 0.4], device=device, dtype=dtype)
+    expected_nonpbc = torch.tensor([14.3996454784255 / 9.6], device=device, dtype=dtype)
+    torch.testing.assert_close(energy_pbc, expected_pbc, atol=1e-10, rtol=1e-10)
+    torch.testing.assert_close(energy_nonpbc, expected_nonpbc, atol=1e-10, rtol=1e-10)


### PR DESCRIPTION
## Summary
- For PolarMACE PBC MM embedding, compute the returned electrostatic term as `E_kspace(ML+MM) - E_kspace(MM)`.
- Return the MM-only k-space term as `mm_mm_electrostatic_energy` for diagnostics and expose it through the ASE calculator.
- Keep the existing non-PBC direct ML-MM Coulomb path unchanged.
- Add tests for MM-MM diagnostic behavior and PBC accounting.

## Validation
Ran in `mace-mlmm2`:

```bash
python -m py_compile \
  /home/jerry528/MLMM/mace/mace/modules/extensions.py \
  /home/jerry528/MLMM/mace/mace/calculators/mace.py \
  /home/jerry528/MLMM/mace/tests/test_mm_field_routes.py \
  /home/jerry528/MLMM/graph_electrostatics/tests/test_features_source_target.py

PYTHONPATH=/home/jerry528/MLMM/graph_electrostatics:/home/jerry528/MLMM/mace pytest -q \
  /home/jerry528/MLMM/graph_electrostatics/tests/test_features_source_target.py \
  /home/jerry528/MLMM/mace/tests/test_mm_field_routes.py
```

Result: `22 passed`.

Also ran the standalone toy water-box validation script from the parent MLMM workspace:

```bash
PYTHONPATH=/home/jerry528/MLMM/graph_electrostatics:/home/jerry528/MLMM/mace \
  python /home/jerry528/MLMM/validate_mace_pbc_mlmm_water_box.py
```

It passed and confirmed `E_returned = E_kspace(ML+MM) - E_kspace(MM)`.