### PR TITLE
Apply missed Codex iteration to virtual_hydrogen_mask (PR #16 follow-up)

### DIFF
--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -1399,20 +1399,55 @@ class PolarMACE(ScaleShiftMACE):
         # J. Phys. Chem. A): cap atoms contribute zero density to all
         # Coulomb sums but remain real atoms for the rest of the model
         # (atomic-energy contribution, exchange-correlation features,
-        # field-dependent polarization).
+        # field-dependent polarization during the SCF iteration).
         #
         # ``data["virtual_hydrogen_mask"]`` is an optional boolean
         # tensor of shape (N,), True for atoms whose electrostatic
         # source coefficients should be zeroed before any Coulomb sum.
         # Default (mask absent or all-False): no change in behavior.
+        #
+        # Note: the SCF polarization field path (the source_feats_alpha
+        # / source_feats_beta calls earlier in this forward) sees the
+        # *unmasked* spin charges. This is intentional under the Z1
+        # convention — the cap participates in the SCF polarization
+        # response so that the rest of the molecule's predicted
+        # multipoles correctly reflect a chemically saturated valence,
+        # but the cap's *output* electrostatic source contribution is
+        # zeroed by the mask below before any Coulomb sum.
         virtual_hydrogen_mask = _get_optional_data_tensor(
             data, "virtual_hydrogen_mask"
         )
         if virtual_hydrogen_mask is not None:
+            # Defensive: align device with the density tensor and
+            # validate shape so a length mismatch raises a clear
+            # error rather than silently broadcasting. (Codex review
+            # MINOR finding.)
+            virtual_hydrogen_mask = virtual_hydrogen_mask.to(
+                charge_density_mul_ir.device
+            )
+            if virtual_hydrogen_mask.shape != (charge_density_mul_ir.shape[0],):
+                raise ValueError(
+                    "virtual_hydrogen_mask shape "
+                    f"{tuple(virtual_hydrogen_mask.shape)} does not "
+                    f"match number of atoms "
+                    f"{charge_density_mul_ir.shape[0]}; expected a "
+                    "1D bool tensor of length N."
+                )
             keep = (~virtual_hydrogen_mask.bool()).to(
                 charge_density_mul_ir.dtype
             )
             keep_2d = keep.view(-1, 1)
+            # Capture the cap monopole charge that's about to be
+            # zeroed. The earlier scatter_normalize_charges_ calls
+            # enforce sum(monopole) == data["total_charge"] over ALL
+            # atoms (including caps), so naively zeroing caps would
+            # leave sum(monopole) over real atoms below the requested
+            # total. Redistribute the lost cap monopole equally over
+            # the remaining real atoms (per-graph) to preserve charge
+            # conservation. (Codex review MAJOR finding.)
+            cap_monopole_per_atom = charge_density_mul_ir[:, 0] * (
+                1.0 - keep
+            )
             charge_density_mul_ir = charge_density_mul_ir * keep_2d
             spin_density_mul_ir = spin_density_mul_ir * keep_2d
             spin_charge_density_mul_ir = (
@@ -1420,6 +1455,37 @@ class PolarMACE(ScaleShiftMACE):
             )
             charge_density = charge_density * keep_2d
             spin_density = spin_density * keep_2d
+
+            graph_count = int(num_graphs)
+            cap_monopole_per_graph = scatter_sum(
+                cap_monopole_per_atom,
+                data["batch"],
+                dim=0,
+                dim_size=graph_count,
+            )
+            n_real_per_graph = scatter_sum(
+                keep,
+                data["batch"],
+                dim=0,
+                dim_size=graph_count,
+            )
+            # Avoid divide-by-zero in graphs where every atom is
+            # masked (degenerate / unit-test case). In that case the
+            # graph's electrostatic contribution is zero anyway.
+            safe_n = n_real_per_graph.clamp_min(1.0)
+            delta_per_atom = (
+                cap_monopole_per_graph / safe_n
+            )[data["batch"]] * keep
+            # Add to the monopole channel of charge_density_mul_ir
+            # and the (only) channel of charge_density. Higher
+            # multipoles (l>=1) on caps were also zeroed but are not
+            # redistributed — under Z1 the cap carries no dipole
+            # either, and the real atoms' dipoles are already SCF-
+            # converged for the capped molecule.
+            mono_correction = torch.zeros_like(charge_density_mul_ir)
+            mono_correction[:, 0] = delta_per_atom
+            charge_density_mul_ir = charge_density_mul_ir + mono_correction
+            charge_density = charge_density + mono_correction
         total_charge, total_dipole = compute_total_charge_dipole_permuted(
             charge_density_mul_ir, positions, data["batch"], num_graphs
         )

--- a/tests/test_virtual_hydrogen_mask.py
+++ b/tests/test_virtual_hydrogen_mask.py
@@ -282,3 +282,42 @@ def test_virtual_hydrogen_mask_shape_validation(minimal_model):
     )
     with pytest.raises(ValueError, match=r"virtual_hydrogen_mask shape"):
         model(data, training=False, compute_force=True)
+
+
+def test_virtual_hydrogen_mask_keeps_cap_forces_nonzero(minimal_model):
+    """Masked atoms must still receive forces from non-electrostatic
+    parts of the model (atomic-energy contribution, message-passing
+    interactions, exchange-correlation features). The mask zeroes
+    only their *electrostatic source coefficients*, not their force.
+
+    Codex review CHECK 2 recommendation: openmm-ml's ONIOM closure
+    redistributes cap forces onto Q,M atoms via a Jacobian; if the
+    cap rows in ``out["forces"]`` were silently zeroed by the mask,
+    the redistribution would produce identically zero contribution
+    to Q,M and the cap's force would be lost. This test pins that
+    masked-atom force rows are non-zero so the redistribution
+    pipeline gets meaningful data.
+    """
+    model, device, dtype = minimal_model
+    data = _build_batch(device, dtype)
+    n_atoms = data["positions"].shape[0]
+
+    # Mask atom 0 (treat it as a cap): its electrostatic source
+    # contribution is zeroed, but force on atom 0 must still be
+    # non-zero from message-passing + atomic-energy contributions.
+    data["virtual_hydrogen_mask"] = torch.tensor(
+        [True, False], dtype=torch.bool, device=device
+    )
+    out = model(data, training=False, compute_force=True)
+    forces = out["forces"].detach()
+    assert forces.shape[0] == n_atoms, (
+        "Forces array should still have one row per input atom, "
+        f"including masked ones. Got shape {tuple(forces.shape)}."
+    )
+    masked_force = forces[0]
+    masked_force_norm = float(torch.linalg.norm(masked_force))
+    assert masked_force_norm > 1e-12, (
+        "Masked atom force should be non-zero — only its electrostatic "
+        "source contribution is zeroed, not the rest of the model. "
+        f"Got masked force = {masked_force.tolist()}."
+    )

--- a/tests/test_virtual_hydrogen_mask.py
+++ b/tests/test_virtual_hydrogen_mask.py
@@ -218,3 +218,67 @@ def test_virtual_hydrogen_mask_one_atom_drops_its_contribution(minimal_model):
     # If atom 0 had predicted charge of meaningful magnitude, |e_full|
     # ≠ |e_masked|. We don't make stronger claims about sign here
     # because the energy can be small and noisy in this tiny test.
+
+
+def test_virtual_hydrogen_mask_preserves_total_charge(minimal_model):
+    """When the user requests a specific total charge (via
+    ``data['total_charge']``), the masking must not silently shift the
+    sum of monopole density across real atoms below the requested
+    value. Codex review MAJOR finding: pre-masking, the
+    ``scatter_normalize_charges_`` step distributes deficit/surplus
+    over ALL atoms including caps; naively zeroing caps would leave
+    real atoms short. The mask code now redistributes the lost cap
+    monopole back over real atoms to preserve total charge.
+
+    Verify by checking that the sum of returned monopole density over
+    the masked atoms matches the sum without masking, within float64
+    tolerance.
+    """
+    model, device, dtype = minimal_model
+    data = _build_batch(device, dtype)
+
+    # Set a non-zero requested total charge to exercise the
+    # normalization scatter on the path that has the bug.
+    data["total_charge"] = torch.tensor([0.5], device=device, dtype=dtype)
+
+    out_unmasked = model(data, training=False, compute_force=True)
+    sum_full = float(
+        out_unmasked["density_coefficients"][:, 0].detach().sum()
+    )
+
+    data_mask = dict(data)
+    data_mask["virtual_hydrogen_mask"] = torch.tensor(
+        [True, False], dtype=torch.bool, device=device
+    )
+    out_masked = model(data_mask, training=False, compute_force=True)
+    sum_masked_real = float(
+        out_masked["density_coefficients"][:, 0].detach().sum()
+    )
+
+    # Both sums should equal the requested total charge (within
+    # the SCF / float64 tolerance of the underlying solver).
+    expected_total = 0.5
+    assert sum_full == pytest.approx(expected_total, abs=1e-6), (
+        "Unmasked total monopole density should match requested "
+        f"total_charge. Got {sum_full}, expected {expected_total}."
+    )
+    assert sum_masked_real == pytest.approx(expected_total, abs=1e-6), (
+        "Masked total monopole density should still match requested "
+        f"total_charge after cap charge is redistributed onto real "
+        f"atoms. Got {sum_masked_real}, expected {expected_total}."
+    )
+
+
+def test_virtual_hydrogen_mask_shape_validation(minimal_model):
+    """A wrong-shape mask raises a clear error instead of silently
+    broadcasting. (Codex review MINOR finding.)"""
+    model, device, dtype = minimal_model
+    data = _build_batch(device, dtype)
+    n_atoms = data["positions"].shape[0]
+
+    # Wrong length: n_atoms + 1.
+    data["virtual_hydrogen_mask"] = torch.zeros(
+        n_atoms + 1, dtype=torch.bool, device=device
+    )
+    with pytest.raises(ValueError, match=r"virtual_hydrogen_mask shape"):
+        model(data, training=False, compute_force=True)


### PR DESCRIPTION
## Summary

Follow-up to PR #16 (virtual_hydrogen_mask). The merge of #16 picked up only the initial commit; my follow-up iteration commit addressing the Codex peer-review findings was missed. This PR re-applies that iteration plus an additional regression test from the same review pass.

Three findings to pick up:

### MAJOR: Charge conservation under Z1 + non-zero total_charge

Before this fix: \`scatter_normalize_charges_\` distributed deficit/surplus over **all** atoms (including caps) before masking. Zeroing cap rows then lost the share assigned to caps — \`sum(monopole_density)\` over real atoms ended up below the user's requested \`total_charge\`.

Fix: capture the cap monopole charge that's about to be zeroed, redistribute it equally over remaining real atoms (per-graph, via \`scatter_sum\`). Total charge is preserved while caps still contribute zero to all Coulomb sums.

Higher multipoles (l ≥ 1) on caps are zeroed without redistribution — under Z1 the cap carries no dipole, and the SCF-converged dipoles on real atoms already reflect the capped molecule's chemistry.

### MINOR: Shape and device validation

Before: a wrong-shape mask silently broadcast or hit a confusing error deep in the multiply. A device mismatch on GPU runs gave an unclear error.

Fix: explicit \`.to(device)\` and \`ValueError\` on shape mismatch with a clear message.

### MINOR: SCF spin-charge path documentation

Codex flagged that the SCF polarization field (\`source_feats_alpha\` / \`source_feats_beta\` earlier in the forward) sees the *unmasked* spin charges. After review this is intentional under Z1 — the cap is electronically real and participates in SCF iteration so the rest of the molecule's predicted multipoles converge correctly for a chemically saturated valence; only the cap's *output* electrostatic source contribution is zeroed. Comment block added to make this explicit.

### CHECK 2 recommendation: cap-forces-retained regression test

Codex also recommended adding a test that pins masked-atom force rows are *non-zero* (they receive force from the non-electrostatic parts of the model — atomic energies, message passing). I documented the expected behavior in the original commit but didn't write the test; this PR adds it.

Why this matters: openmm-ml's ONIOM closure redistributes cap forces onto Q,M atoms via a Jacobian. If the mask had been over-eager and silently zeroed cap rows in \`out["forces"]\` along with the electrostatic source coefficients, the cap's chemistry would be lost from the final host force.

## Tests

\`tests/test_virtual_hydrogen_mask.py\` (now 6 tests, was 3 in mlmm):
- [x] default-absent is no-op
- [x] all-True kills electrostatic_energy and ml_mm_electrostatic_energy
- [x] masking one atom changes the energy
- [x] **NEW**: charge conservation under non-zero \`total_charge\`
- [x] **NEW**: shape/device validation
- [x] **NEW**: cap forces remain non-zero (CHECK 2)

\`tests/test_mm_field_routes.py\`: 10/10 still pass (default code path untouched).

## Roadmap

This closes the loop on the Codex review of PR #16. With this merged, the openmm-ml side (PR #12) lands the user-facing ONIOM Slice 3' on top of a fully-pinned MACE side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)