### PR TITLE
fix(magnetic): preserve FT-head data-derived scale_shift.shift

### DIFF
--- a/mace/tools/finetuning_utils.py
+++ b/mace/tools/finetuning_utils.py
@@ -507,6 +507,11 @@ def transfer_foundation_readouts_and_scale_shift(
         and model_foundations.scale_shift is not None
     ):
         n_heads = len(model_heads)
+        pt_head_idx = (
+            model_heads.index("pt_head")
+            if (n_heads > 1 and "pt_head" in model_heads)
+            else None
+        )
         if use_scale:
             target = model.scale_shift.scale
             new = model_foundations.scale_shift.scale.repeat(n_heads).clone()
@@ -514,11 +519,20 @@ def transfer_foundation_readouts_and_scale_shift(
             if new.shape == target.shape:
                 model.scale_shift.scale = new
         if use_shift:
-            target = model.scale_shift.shift
-            new = model_foundations.scale_shift.shift.repeat(n_heads).clone()
-            new = new.to(dtype=target.dtype, device=target.device)
-            if new.shape == target.shape:
-                model.scale_shift.shift = new
+            if pt_head_idx is not None:
+                target = model.scale_shift.shift
+                src = (
+                    model_foundations.scale_shift.shift.flatten()[0]
+                    .to(dtype=target.dtype, device=target.device)
+                )
+                if target.ndim == 1 and target.shape[0] == n_heads:
+                    target[pt_head_idx] = src
+            else:
+                target = model.scale_shift.shift
+                new = model_foundations.scale_shift.shift.repeat(n_heads).clone()
+                new = new.to(dtype=target.dtype, device=target.device)
+                if new.shape == target.shape:
+                    model.scale_shift.shift = new
 
     # Broadcast any remaining foundation buffer/parameter whose model
     # counterpart differs only in a singleton head dim. Catches the
@@ -531,7 +545,10 @@ def transfer_foundation_readouts_and_scale_shift(
     n_heads = len(model_heads)
     if n_heads > 1:
         import logging as _logging
-        skip_names = {"atomic_energies_fn.atomic_energies"}
+        skip_names = {
+            "atomic_energies_fn.atomic_energies",
+            "scale_shift.shift",
+        }
         model_state = model.state_dict()
         foundation_state = model_foundations.state_dict()
         n_broadcast = 0


### PR DESCRIPTION
## Summary
- When a multihead replay setup is detected (\`pt_head\` in \`model.heads\`), only overwrite \`scale_shift.shift\` into the \`pt_head\` slot; FT heads keep the data-derived shift that \`run_train.py\` computed.
- Scale still broadcasts to all heads (it multiplies the gradient, so a data-derived scale would distort forces — verified: 5x force degradation when scale was also kept).
- Single-head / no-\`pt_head\` paths unchanged.

## Smoke result on FeNi nonSOC multihead replay
| | before | after |
|---|---|---|
| pt_head MAE_E_per_atom | 61 meV/atom | **61 meV/atom** (foundation match, unchanged) |
| Default MAE_E_per_atom | 5116 meV/atom | **557 meV/atom** (9x better) |
| Default MAE_F | 75.86 meV/Å | **75.86 meV/Å** (unchanged) |
| Default MAE_stress | 15.17 meV/Å³ | **15.17 meV/Å³** (unchanged) |

## Test plan
- [x] FeNi nonSOC smoke (job 2177645) — pt_head & Default initial validation as above
- [ ] confirm Default convergence after epoch 0-3 (training continues in background)