### PR TITLE
PolarMACE: direct ML×MM cross-Coulomb (skip mixed-then-subtract)

### DIFF
--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -1120,9 +1120,22 @@ class PolarMACE(ScaleShiftMACE):
             )
         return rho
 
+    @staticmethod
+    def _pad_to_num_graphs(
+        per_graph: torch.Tensor, num_graphs: int
+    ) -> torch.Tensor:
+        if per_graph.shape[0] == num_graphs:
+            return per_graph
+        padded = torch.zeros(
+            num_graphs, dtype=per_graph.dtype, device=per_graph.device
+        )
+        if per_graph.shape[0] > 0:
+            limit = min(per_graph.shape[0], num_graphs)
+            padded[:limit] = per_graph[:limit]
+        return padded
+
     def _pbc_mm_cross_energy(
         self,
-        *,
         ml_features: torch.Tensor,
         ml_positions: torch.Tensor,
         ml_batch: torch.Tensor,
@@ -1136,7 +1149,7 @@ class PolarMACE(ScaleShiftMACE):
         volume: torch.Tensor,
         pbc: torch.Tensor,
         mm_chunk_size: int = 4096,
-    ):
+    ) -> "tuple[torch.Tensor, torch.Tensor]":
         n_ml = max(1, int(ml_features.shape[0]))
         rho_ml = self._assemble_rho_chunked(
             ml_features, ml_positions, ml_batch,
@@ -1157,6 +1170,7 @@ class PolarMACE(ScaleShiftMACE):
         cross_kspace_E = volume * cross_kspace_E / (2 * math.pi) ** 6
 
         if getattr(self.coulomb_energy, "include_pbc_corrections", True):
+            num_graphs = int(volume.shape[0])
             mixed_features = torch.cat([ml_features, mm_features], dim=0)
             mixed_positions = torch.cat([ml_positions, mm_positions], dim=0)
             mixed_batch = torch.cat([ml_batch, mm_batch], dim=0)
@@ -1168,20 +1182,41 @@ class PolarMACE(ScaleShiftMACE):
                 else mixed_features
             )
             mol = self.coulomb_energy.monopole_dipole_correction
+            # `MonopoleDipoleCorrectionBlock` and `slab_dipole_correction_energy`
+            # both scatter without an explicit dim_size, so the result is sized
+            # to max(batch)+1 — shorter than `volume` when the trailing graph
+            # has no ML or no MM nodes. Pad each term to num_graphs before
+            # subtracting so a per-graph (mixed - ML - MM) algebra is exact.
             cross_mol = (
-                mol(mixed_lm, mixed_positions, volume, mixed_batch)
-                - mol(ml_lm, ml_positions, volume, ml_batch)
-                - mol(mm_lm, mm_positions, volume, mm_batch)
+                self._pad_to_num_graphs(
+                    mol(mixed_lm, mixed_positions, volume, mixed_batch),
+                    num_graphs,
+                )
+                - self._pad_to_num_graphs(
+                    mol(ml_lm, ml_positions, volume, ml_batch), num_graphs
+                )
+                - self._pad_to_num_graphs(
+                    mol(mm_lm, mm_positions, volume, mm_batch), num_graphs
+                )
             )
             cross_slab = (
-                slab_dipole_correction_energy(
-                    mixed_lm, mixed_positions, volume, mixed_batch
+                self._pad_to_num_graphs(
+                    slab_dipole_correction_energy(
+                        mixed_lm, mixed_positions, volume, mixed_batch
+                    ),
+                    num_graphs,
                 )
-                - slab_dipole_correction_energy(
-                    ml_lm, ml_positions, volume, ml_batch
+                - self._pad_to_num_graphs(
+                    slab_dipole_correction_energy(
+                        ml_lm, ml_positions, volume, ml_batch
+                    ),
+                    num_graphs,
                 )
-                - slab_dipole_correction_energy(
-                    mm_lm, mm_positions, volume, mm_batch
+                - self._pad_to_num_graphs(
+                    slab_dipole_correction_energy(
+                        mm_lm, mm_positions, volume, mm_batch
+                    ),
+                    num_graphs,
                 )
             )
             slab_pattern = torch.tensor(

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Dict, List, Optional
 
 import torch
@@ -6,12 +7,17 @@ from e3nn.util.jit import compile_mode
 
 try:
     from graph_longrange.energy import GTOElectrostaticEnergy
-    from graph_longrange.features import GTOElectrostaticFeatures
+    from graph_longrange.features import (
+        GTOElectrostaticFeatures,
+        assemble_fourier_series_batch,
+    )
     from graph_longrange.gto_utils import (
         DisplacedGTOExternalFieldBlock,
         gto_basis_kspace_cutoff,
     )
     from graph_longrange.kspace import compute_k_vectors_flat
+    from graph_longrange.slabs import slab_dipole_correction_energy
+    from graph_longrange.utils import FIELD_CONSTANT
 
     GRAPH_LONGRANGE_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
@@ -333,6 +339,7 @@ class PolarMACE(ScaleShiftMACE):
         include_electrostatic_self_interaction: bool = False,
         add_local_electron_energy: bool = False,
         compute_mm_coulomb: bool = True,
+        mm_chunk_size: int = 4096,
         quadrupole_feature_corrections: bool = False,
         return_electrostatic_potentials: bool = False,
         field_feature_norms: Optional[List[float]] = None,
@@ -412,6 +419,7 @@ class PolarMACE(ScaleShiftMACE):
         # polarisation response.
         # Default True preserves existing behaviour for old saved models.
         self.compute_mm_coulomb = compute_mm_coulomb
+        self.mm_chunk_size = int(mm_chunk_size)
         self.quadrupole_feature_corrections = quadrupole_feature_corrections
         self.field_si = field_si
         self.keep_last_layer_irreps = True
@@ -1068,6 +1076,129 @@ class PolarMACE(ScaleShiftMACE):
             return None
         return charge_density_mul_ir[:, 1:4]
 
+    def _assemble_rho_chunked(
+        self,
+        source_feats: torch.Tensor,
+        node_positions: torch.Tensor,
+        batch: torch.Tensor,
+        k_vectors: torch.Tensor,
+        k_norm2: torch.Tensor,
+        k_vector_batch: torch.Tensor,
+        k0_mask: torch.Tensor,
+        volume: torch.Tensor,
+        chunk_size: int,
+    ) -> torch.Tensor:
+        density_basis_fs = self.coulomb_energy.density_basis(
+            k_vectors, k_norm2, k0_mask
+        )
+        volume_per_k = volume.reshape(-1)[k_vector_batch]
+        n_k = k_vectors.shape[0]
+        rho = torch.zeros(
+            (n_k, 2), dtype=source_feats.dtype, device=source_feats.device
+        )
+        n_nodes = source_feats.shape[0]
+        if n_nodes == 0:
+            return rho
+        step = max(1, int(chunk_size))
+        for start in range(0, n_nodes, step):
+            end = min(start + step, n_nodes)
+            chunk_feats = source_feats[start:end]
+            chunk_pos = node_positions[start:end]
+            chunk_batch = batch[start:end]
+            inner_products = k_vectors @ chunk_pos.t()
+            mask = (k_vector_batch[:, None] == chunk_batch[None, :]).to(
+                inner_products.dtype
+            )
+            cosines = torch.cos(inner_products) * mask
+            sines = torch.sin(inner_products) * mask
+            rho = rho + assemble_fourier_series_batch(
+                source_feats=chunk_feats,
+                cosines=cosines,
+                sines=sines,
+                density_basis_fs=density_basis_fs,
+                volume_per_k=volume_per_k,
+            )
+        return rho
+
+    def _pbc_mm_cross_energy(
+        self,
+        *,
+        ml_features: torch.Tensor,
+        ml_positions: torch.Tensor,
+        ml_batch: torch.Tensor,
+        mm_features: torch.Tensor,
+        mm_positions: torch.Tensor,
+        mm_batch: torch.Tensor,
+        k_vectors: torch.Tensor,
+        k_norm2: torch.Tensor,
+        k_vector_batch: torch.Tensor,
+        k0_mask: torch.Tensor,
+        volume: torch.Tensor,
+        pbc: torch.Tensor,
+        mm_chunk_size: int = 4096,
+    ):
+        n_ml = max(1, int(ml_features.shape[0]))
+        rho_ml = self._assemble_rho_chunked(
+            ml_features, ml_positions, ml_batch,
+            k_vectors, k_norm2, k_vector_batch, k0_mask, volume,
+            chunk_size=n_ml,
+        )
+        rho_mm = self._assemble_rho_chunked(
+            mm_features, mm_positions, mm_batch,
+            k_vectors, k_norm2, k_vector_batch, k0_mask, volume,
+            chunk_size=mm_chunk_size,
+        )
+        valid = k0_mask <= 0.0
+        dot = rho_ml[:, 0] * rho_mm[:, 0] + rho_ml[:, 1] * rho_mm[:, 1]
+        per_k = torch.zeros_like(k_norm2)
+        per_k[valid] = 2.0 * FIELD_CONSTANT * dot[valid] / k_norm2[valid]
+        cross_kspace_E = torch.zeros_like(volume)
+        cross_kspace_E.index_add_(0, k_vector_batch, per_k)
+        cross_kspace_E = volume * cross_kspace_E / (2 * math.pi) ** 6
+
+        if getattr(self.coulomb_energy, "include_pbc_corrections", True):
+            mixed_features = torch.cat([ml_features, mm_features], dim=0)
+            mixed_positions = torch.cat([ml_positions, mm_positions], dim=0)
+            mixed_batch = torch.cat([ml_batch, mm_batch], dim=0)
+            ml_lm = ml_features.squeeze(-2) if ml_features.dim() == 3 else ml_features
+            mm_lm = mm_features.squeeze(-2) if mm_features.dim() == 3 else mm_features
+            mixed_lm = (
+                mixed_features.squeeze(-2)
+                if mixed_features.dim() == 3
+                else mixed_features
+            )
+            mol = self.coulomb_energy.monopole_dipole_correction
+            cross_mol = (
+                mol(mixed_lm, mixed_positions, volume, mixed_batch)
+                - mol(ml_lm, ml_positions, volume, ml_batch)
+                - mol(mm_lm, mm_positions, volume, mm_batch)
+            )
+            cross_slab = (
+                slab_dipole_correction_energy(
+                    mixed_lm, mixed_positions, volume, mixed_batch
+                )
+                - slab_dipole_correction_energy(
+                    ml_lm, ml_positions, volume, ml_batch
+                )
+                - slab_dipole_correction_energy(
+                    mm_lm, mm_positions, volume, mm_batch
+                )
+            )
+            slab_pattern = torch.tensor(
+                [0, 0, 1], dtype=torch.bool, device=pbc.device
+            )
+            is_molecule = torch.all(torch.logical_not(pbc), dim=1)
+            is_slab = torch.all(torch.logical_xor(slab_pattern, pbc), dim=1)
+            cross_corr_E = torch.where(
+                is_molecule,
+                cross_mol,
+                torch.where(is_slab, cross_slab, torch.zeros_like(volume)),
+            )
+        else:
+            cross_corr_E = torch.zeros_like(volume)
+
+        return cross_kspace_E, cross_corr_E
+
     def forward(
         self,
         data: Dict[str, torch.Tensor],
@@ -1485,35 +1616,23 @@ class PolarMACE(ScaleShiftMACE):
                     dtype=charge_density_mul_ir.dtype,
                     device=charge_density_mul_ir.device,
                 )
-                mixed_features = torch.cat((charge_density_mul_ir, mm_features), dim=0)
-                mixed_positions = torch.cat((positions, mm_positions_for_grad), dim=0)
-                mixed_batch = torch.cat((data["batch"], mm_source_batch), dim=0)
-                mixed_electrostatic_energy = self.coulomb_energy(
+                cross_kspace_E, cross_corr_E = self._pbc_mm_cross_energy(
+                    ml_features=charge_density_mul_ir,
+                    ml_positions=positions,
+                    ml_batch=data["batch"],
+                    mm_features=mm_features,
+                    mm_positions=mm_positions_for_grad,
+                    mm_batch=mm_source_batch,
                     k_vectors=k_vectors,
                     k_norm2=kv_norms_squared,
                     k_vector_batch=k_vectors_batch,
                     k0_mask=k_vectors_0mask,
-                    source_feats=mixed_features,
-                    node_positions=mixed_positions,
-                    batch=mixed_batch,
                     volume=data["volume"],
                     pbc=data["pbc"].view(-1, 3),
-                    force_pbc_evaluator=use_pbc_evaluator,
+                    mm_chunk_size=self.mm_chunk_size,
                 )
-                mm_mm_electrostatic_energy = self.coulomb_energy(
-                    k_vectors=k_vectors,
-                    k_norm2=kv_norms_squared,
-                    k_vector_batch=k_vectors_batch,
-                    k0_mask=k_vectors_0mask,
-                    source_feats=mm_features,
-                    node_positions=mm_positions_for_grad,
-                    batch=mm_source_batch,
-                    volume=data["volume"],
-                    pbc=data["pbc"].view(-1, 3),
-                    force_pbc_evaluator=use_pbc_evaluator,
-                )
-                electro_energy = mixed_electrostatic_energy - mm_mm_electrostatic_energy
-                ml_mm_electrostatic_energy = electro_energy
+                ml_mm_electrostatic_energy = cross_kspace_E + cross_corr_E
+                electro_energy = electro_energy + ml_mm_electrostatic_energy
                 ml_mm_dipole_energy = torch.zeros_like(electro_energy)
             else:
                 ml_charges = charge_density_mul_ir[:, 0]

--- a/tests/test_polar_mm_cross.py
+++ b/tests/test_polar_mm_cross.py
@@ -1,0 +1,219 @@
+"""Validate PolarMACE's direct ML×MM cross-Coulomb path vs the
+concat-then-subtract reference.
+
+The new helpers (`_assemble_rho_chunked`, `_pbc_mm_cross_energy`) are
+exercised against the original `mixed_E - mm_E - ml_E` identity that
+PolarMACE used to evaluate on the combined ML+MM source list. Chunked vs
+unchunked ρ_MM assembly is also verified to be invariant (since
+``assemble_fourier_series_batch`` is bilinear in the source coefficients,
+per-chunk contributions sum exactly).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+graph_longrange = pytest.importorskip("graph_longrange")
+from graph_longrange.energy import GTOElectrostaticEnergy  # noqa: E402
+from graph_longrange.kspace import compute_k_vectors_flat  # noqa: E402
+
+from mace.modules.extensions import PolarMACE  # noqa: E402
+
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+
+def _mm_charge_features(q: torch.Tensor, m_dim: int) -> torch.Tensor:
+    out = torch.zeros((q.numel(), m_dim), dtype=q.dtype, device=q.device)
+    out[:, 0] = q
+    return out
+
+
+def _make_stub(chunk_size: int) -> object:
+    """Minimal object that satisfies the attribute surface of
+    ``_assemble_rho_chunked`` and ``_pbc_mm_cross_energy``.
+
+    We bypass full PolarMACE construction because both methods only access
+    ``self.coulomb_energy`` and ``self.mm_chunk_size``."""
+    stub = type("Stub", (), {})()
+    stub.coulomb_energy = GTOElectrostaticEnergy(
+        density_max_l=1,
+        density_smearing_width=0.5,
+        kspace_cutoff=3.0,
+        include_self_interaction=False,
+        include_pbc_corrections=True,
+    )
+    stub.mm_chunk_size = chunk_size
+    stub._assemble_rho_chunked = PolarMACE._assemble_rho_chunked.__get__(stub)
+    stub._pbc_mm_cross_energy = PolarMACE._pbc_mm_cross_energy.__get__(stub)
+    stub._pad_to_num_graphs = PolarMACE._pad_to_num_graphs  # staticmethod
+    return stub
+
+
+def _reference_cross(
+    stub,
+    ml_f, ml_r, ml_b,
+    mm_f, mm_r, mm_b,
+    k_vectors, k_norm2, k_vector_batch, k0_mask, volume, pbc,
+):
+    mixed_f = torch.cat([ml_f, mm_f], dim=0)
+    mixed_r = torch.cat([ml_r, mm_r], dim=0)
+    mixed_b = torch.cat([ml_b, mm_b], dim=0)
+    mixed_E = stub.coulomb_energy(
+        k_vectors=k_vectors, k_norm2=k_norm2, k_vector_batch=k_vector_batch,
+        k0_mask=k0_mask, source_feats=mixed_f, node_positions=mixed_r,
+        batch=mixed_b, volume=volume, pbc=pbc, force_pbc_evaluator=True,
+    )
+    mm_E = stub.coulomb_energy(
+        k_vectors=k_vectors, k_norm2=k_norm2, k_vector_batch=k_vector_batch,
+        k0_mask=k0_mask, source_feats=mm_f, node_positions=mm_r,
+        batch=mm_b, volume=volume, pbc=pbc, force_pbc_evaluator=True,
+    )
+    ml_E = stub.coulomb_energy(
+        k_vectors=k_vectors, k_norm2=k_norm2, k_vector_batch=k_vector_batch,
+        k0_mask=k0_mask, source_feats=ml_f, node_positions=ml_r,
+        batch=ml_b, volume=volume, pbc=pbc, force_pbc_evaluator=True,
+    )
+    return (mixed_E - mm_E) - ml_E
+
+
+def _build_inputs(n_mm: int, multipoles: bool, seed: int):
+    torch.manual_seed(seed)
+    nml, m = 4, 4
+    cell = torch.eye(3, dtype=torch.float64).unsqueeze(0) * 10.0
+    rcell = 2 * math.pi * torch.linalg.inv(cell).transpose(-1, -2)
+    volume = torch.det(cell)
+    kv, k2, kb, k0 = compute_k_vectors_flat(3.0, cell, rcell)
+
+    ml_r = (torch.rand(nml, 3, dtype=torch.float64) * 8 + 1).requires_grad_(True)
+    mm_r = (torch.rand(n_mm, 3, dtype=torch.float64) * 8 + 1).requires_grad_(True)
+    ml_f = torch.randn(nml, m, dtype=torch.float64).requires_grad_(True)
+    ml_b = torch.zeros(nml, dtype=torch.long)
+    mm_b = torch.zeros(n_mm, dtype=torch.long)
+    if multipoles:
+        mm_f = torch.randn(n_mm, m, dtype=torch.float64).requires_grad_(True)
+    else:
+        q = torch.randn(n_mm, dtype=torch.float64, requires_grad=True)
+        mm_f = _mm_charge_features(q, m)
+    return dict(
+        ml_r=ml_r, mm_r=mm_r, ml_f=ml_f, mm_f=mm_f, ml_b=ml_b, mm_b=mm_b,
+        kv=kv, k2=k2, kb=kb, k0=k0, volume=volume,
+    )
+
+
+@pytest.mark.parametrize(
+    "pbc, multipoles, n_mm, chunk_size",
+    [
+        (torch.tensor([[True, True, True]]),  False, 10,   4096),
+        (torch.tensor([[True, True, True]]),  True,  10,   4096),
+        (torch.tensor([[True, True, False]]), False, 10,   4096),  # slab
+        (torch.tensor([[True, True, True]]),  False, 128,  4096),  # no chunking (1 chunk)
+        (torch.tensor([[True, True, True]]),  False, 128,  32),    # 4 chunks
+        (torch.tensor([[True, True, True]]),  False, 128,  1),     # per-node
+        (torch.tensor([[True, True, True]]),  True,  128,  37),    # uneven chunks
+    ],
+    ids=[
+        "full_pbc_charges_n10_chunk4096",
+        "full_pbc_multipoles_n10_chunk4096",
+        "slab_pbc_charges_n10_chunk4096",
+        "full_pbc_charges_n128_nochunk",
+        "full_pbc_charges_n128_chunk32",
+        "full_pbc_charges_n128_chunk1",
+        "full_pbc_multipoles_n128_chunk37_uneven",
+    ],
+)
+def test_mm_cross_matches_concat_minus_mm(pbc, multipoles, n_mm, chunk_size):
+    torch.set_default_dtype(torch.float64)
+    x = _build_inputs(n_mm=n_mm, multipoles=multipoles, seed=11)
+    stub = _make_stub(chunk_size=chunk_size)
+
+    cross_k, cross_corr = stub._pbc_mm_cross_energy(
+        ml_features=x["ml_f"], ml_positions=x["ml_r"], ml_batch=x["ml_b"],
+        mm_features=x["mm_f"], mm_positions=x["mm_r"], mm_batch=x["mm_b"],
+        k_vectors=x["kv"], k_norm2=x["k2"], k_vector_batch=x["kb"],
+        k0_mask=x["k0"], volume=x["volume"], pbc=pbc,
+        mm_chunk_size=chunk_size,
+    )
+    cross_new = cross_k + cross_corr
+    cross_ref = _reference_cross(
+        stub,
+        x["ml_f"], x["ml_r"], x["ml_b"],
+        x["mm_f"], x["mm_r"], x["mm_b"],
+        x["kv"], x["k2"], x["kb"], x["k0"], x["volume"], pbc,
+    )
+
+    g_new = torch.autograd.grad(
+        cross_new.sum(), [x["ml_r"], x["mm_r"], x["ml_f"]],
+        retain_graph=True, allow_unused=True,
+    )
+    g_ref = torch.autograd.grad(
+        cross_ref.sum(), [x["ml_r"], x["mm_r"], x["ml_f"]],
+        retain_graph=True, allow_unused=True,
+    )
+
+    ed = (cross_new - cross_ref).abs().max().item()
+    gd = max(
+        (a - b).abs().max().item()
+        for a, b in zip(g_new, g_ref)
+        if a is not None and b is not None
+    )
+    assert ed < 1e-9, f"energy mismatch: {ed:.3e}"
+    assert gd < 1e-8, f"gradient mismatch: {gd:.3e}"
+
+
+def test_mm_cross_handles_trailing_graph_without_mm():
+    """Batched case where the trailing graph has ML but no MM nodes.
+
+    `MonopoleDipoleCorrectionBlock.forward()` scatters without `dim_size`,
+    so the raw `corr(MM)` tensor would be shorter than `volume`; the cross
+    subtraction has to pad to `num_graphs` for the algebra to stay exact.
+    """
+    torch.set_default_dtype(torch.float64)
+    torch.manual_seed(17)
+    chunk_size = 4096
+    nml_per, n_mm_g0, m = 3, 8, 4
+    num_graphs = 2
+    cell = (torch.eye(3, dtype=torch.float64).unsqueeze(0) * 10.0).repeat(
+        num_graphs, 1, 1
+    )
+    rcell = 2 * math.pi * torch.linalg.inv(cell).transpose(-1, -2)
+    volume = torch.det(cell)
+    kv, k2, kb, k0 = compute_k_vectors_flat(3.0, cell, rcell)
+
+    # ML in both graphs
+    ml_r = (torch.rand(nml_per * num_graphs, 3, dtype=torch.float64) * 8 + 1).requires_grad_(True)
+    ml_f = torch.randn(nml_per * num_graphs, m, dtype=torch.float64).requires_grad_(True)
+    ml_b = torch.cat([torch.full((nml_per,), g, dtype=torch.long) for g in range(num_graphs)])
+
+    # MM only in graph 0
+    mm_r = (torch.rand(n_mm_g0, 3, dtype=torch.float64) * 8 + 1).requires_grad_(True)
+    q = torch.randn(n_mm_g0, dtype=torch.float64, requires_grad=True)
+    mm_f = _mm_charge_features(q, m)
+    mm_b = torch.zeros(n_mm_g0, dtype=torch.long)
+
+    pbc = torch.tensor([[True, True, True]], dtype=torch.bool).repeat(num_graphs, 1)
+    stub = _make_stub(chunk_size=chunk_size)
+
+    cross_k, cross_corr = stub._pbc_mm_cross_energy(
+        ml_features=ml_f, ml_positions=ml_r, ml_batch=ml_b,
+        mm_features=mm_f, mm_positions=mm_r, mm_batch=mm_b,
+        k_vectors=kv, k_norm2=k2, k_vector_batch=kb, k0_mask=k0,
+        volume=volume, pbc=pbc, mm_chunk_size=chunk_size,
+    )
+    cross_new = cross_k + cross_corr
+
+    cross_ref = _reference_cross(
+        stub, ml_f, ml_r, ml_b, mm_f, mm_r, mm_b,
+        kv, k2, kb, k0, volume, pbc,
+    )
+
+    assert cross_new.shape == volume.shape
+    assert cross_ref.shape == volume.shape
+    # Graph 1 has no MM nodes; the cross must be exactly zero there.
+    assert cross_new[1].abs().item() < 1e-12
+    assert cross_ref[1].abs().item() < 1e-12
+
+    ed = (cross_new - cross_ref).abs().max().item()
+    assert ed < 1e-9, f"energy mismatch: {ed:.3e}"


### PR DESCRIPTION
## Summary

Replace the concat-then-subtract ML/MM Coulomb pattern in \`PolarMACE.forward\` with a direct cross-term evaluator plus chunked ρ_MM assembly.

Stacked on **#19** (\`feat/optional-mm-coulomb\`) since the refactor lives inside the \`compute_mm_coulomb\` runtime gate added there.

## Motivation

The current code computes
\`\`\`
mixed_E = coulomb_energy(source_feats=[ρ_ML; ρ_MM], …)  # O(n_k · (n_ML + n_MM))
mm_E    = coulomb_energy(source_feats=ρ_MM, …)         # O(n_k · n_MM)
electro_energy = mixed_E - mm_E                         # = E_ML + cross
\`\`\`
which redundantly forms \`|ρ_ML + ρ_MM|²\` on the combined node list and then subtracts \`|ρ_MM|²\`. The standalone ML-only \`coulomb_energy\` call earlier in the same forward is overwritten.

## What this PR does

- **\`_pbc_mm_cross_energy(…)\`** computes only the bilinear cross-Coulomb term directly:
  \`\`\`
  cross_kspace = V · Σ_k 2·FIELD_CONSTANT · (ρ_ML · ρ_MM)(k) / k² / (2π)⁶    (k=0 excluded)
  cross_corr   = mol(ML+MM) − mol(ML) − mol(MM)  +  slab analogue   (per-graph topology mask)
  electro_energy = electro_energy + cross_kspace + cross_corr
  \`\`\`
  The standalone ML-only k-space call is reused (no longer overwritten).

- **\`_assemble_rho_chunked(…, mm_chunk_size)\`** accumulates ρ_MM(k) in chunks of \`mm_chunk_size\` MM nodes (new constructor arg, default 4096). Linear in n_MM, so per-chunk contributions sum exactly.

- **\`_pad_to_num_graphs\`** wraps the cross-correction subtraction so per-graph subtraction is exact even when batched graphs have no ML or no MM nodes. (\`MonopoleDipoleCorrectionBlock\` and \`slab_dipole_correction_energy\` scatter without an explicit \`dim_size\`, so their output is sized to \`max(batch)+1\` — addresses codex review on 9382afe.)

Backend (\`graph_longrange\`) is untouched.

## Validation

\`tests/test_polar_mm_cross.py\` (new):
- 7 parametric cases over PBC variants × MM-charge vs MM-multipole × \`chunk_size ∈ {4096, 32, 1, 37}\`. All pass at float64 noise (energy ≤ 1.7e-13, gradient ≤ 1.3e-13). Confirms chunking invariance and autograd-bit-equivalence of energy + ML/MM forces vs the current concat-minus-MM identity.
- 1 batched case (\`test_mm_cross_handles_trailing_graph_without_mm\`): graph 1 has ML but zero MM. Cross is exactly 0 there; total matches reference.

## Perf

H100 NVL, 20-Å cube, n_k=1872 (float64; fwd+bwd):

| n_MM | old (ms) | new (ms) | speed | peak GB old | peak GB new | mem savings |
|---|---|---|---|---|---|---|
| 100 | 5.4 | 5.9 | 0.91× | 0.08 | 0.07 | 1.08× |
| 500 | 5.5 | 6.0 | 0.91× | 0.14 | 0.11 | 1.27× |
| 2 000 | 5.5 | 6.0 | 0.91× | 0.35 | 0.24 | 1.48× |
| 8 000 | 7.1 | 7.3 | 0.97× | 1.21 | 0.64 | **1.90×** |
| 32 000 | 16.7 | 13.8 | **1.22×** | 4.65 | 2.00 | **2.33×** |

Memory is the headline win — at n_MM=32 000, peak fwd+bwd memory drops from 4.65 GB → 2.0 GB. Wallclock is essentially flat for small n_MM (kernel-launch bound on H100) and turns over to a real ~1.2× speedup at 32 000+.

## Test plan

- [x] \`pytest tests/test_polar_mm_cross.py\` — 8 / 8 pass
- [ ] Confirm no regression vs PR #19's runtime gate (\`compute_mm_coulomb=False\`)
- [ ] Run on a real PolarMACE checkpoint with a representative QM/MM batch and compare energies + forces vs the pre-refactor model

🤖 Generated with [Claude Code](https://claude.com/claude-code)